### PR TITLE
[FP8] Support Weight Dequantize FP16xFP8_E4M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ For more detailed information on benchmark sets with other formats (NF4/FP4) and
 |:-----------:|:-----------:|:---------------:|:---------------:|:----------------------:|:----------------------:|
 |     FP16    |     FP16    |       FP16      |       FP16      |          **√**         |   V100(SM_70)/A100(SM_80)/A6000(SM_86)/RTX 4090(SM_89) |
 |     FP16    |   FP4_E2M1  |       FP16      |       FP16      |          **√**         |   V100(SM_70)/A100(SM_80)/A6000(SM_86)/RTX 4090(SM_89) |
+|     FP16    |   FP8_E4M3  |       FP16      |       FP16      |          **√**         |   V100(SM_70)/A100(SM_80)/A6000(SM_86)/RTX 4090(SM_89) |
 |     FP16    |     INT8    |       FP16      |       FP16      |          **√**         |   V100(SM_70)/A100(SM_80)/A6000(SM_86)/RTX 4090(SM_89) |
 |     FP16    |     UINT4/INT4    |       FP16      |       FP16      |          **√**         |   V100(SM_70)/A100(SM_80)/A6000(SM_86)/RTX 4090(SM_89) |
 |     FP16    |     UINT2/INT2    |       FP16      |       FP16      |          **√**         |   V100(SM_70)/A100(SM_80)/A6000(SM_86)/RTX 4090(SM_89) |

--- a/python/bitblas/gpu/gemv_dequantize.py
+++ b/python/bitblas/gpu/gemv_dequantize.py
@@ -50,7 +50,7 @@ class GEMVWithDequantizeInfo(GPUScheduleRule):
             # check source format in ["int", "fp", "nf"]
             conditions.append("source_format" in weight_decode_info)
             conditions.append(
-                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf"])
+                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf", "fp_e5m2", "fp_e4m3"])
             # check source bits in [1, 2, 4, 8]
             conditions.append(weight_decode_info["source_format"]["bits"] in [1, 2, 4, 8])
             # check target format in ["float16", "int8"]
@@ -214,7 +214,7 @@ class GEMVWithDequantizeInfo(GPUScheduleRule):
             # check source format in ["int", "fp", "nf"]
             conditions.append("source_format" in weight_decode_info)
             conditions.append(
-                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf"])
+                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf", "fp_e5m2", "fp_e4m3"])
             # check source bits in [1, 2, 4, 8]
             conditions.append(weight_decode_info["source_format"]["bits"] in [1, 2, 4, 8])
             # check target format in ["float16", "int8"]

--- a/python/bitblas/gpu/gemv_dequantize.py
+++ b/python/bitblas/gpu/gemv_dequantize.py
@@ -49,8 +49,8 @@ class GEMVWithDequantizeInfo(GPUScheduleRule):
             conditions = []
             # check source format in ["int", "fp", "nf"]
             conditions.append("source_format" in weight_decode_info)
-            conditions.append(
-                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf", "fp_e5m2", "fp_e4m3"])
+            conditions.append(weight_decode_info["source_format"]["format"] in
+                              ["uint", "int", "fp", "nf", "fp_e5m2", "fp_e4m3"])
             # check source bits in [1, 2, 4, 8]
             conditions.append(weight_decode_info["source_format"]["bits"] in [1, 2, 4, 8])
             # check target format in ["float16", "int8"]
@@ -213,8 +213,8 @@ class GEMVWithDequantizeInfo(GPUScheduleRule):
             conditions = []
             # check source format in ["int", "fp", "nf"]
             conditions.append("source_format" in weight_decode_info)
-            conditions.append(
-                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf", "fp_e5m2", "fp_e4m3"])
+            conditions.append(weight_decode_info["source_format"]["format"] in
+                              ["uint", "int", "fp", "nf", "fp_e5m2", "fp_e4m3"])
             # check source bits in [1, 2, 4, 8]
             conditions.append(weight_decode_info["source_format"]["bits"] in [1, 2, 4, 8])
             # check target format in ["float16", "int8"]

--- a/python/bitblas/gpu/matmul_mma_dequantize.py
+++ b/python/bitblas/gpu/matmul_mma_dequantize.py
@@ -126,8 +126,8 @@ class MatmulTensorizationMMAWithDequantizeInfo(GPUScheduleRule):
             conditions = []
             # check source format in ["int", "fp", "nf"]
             conditions.append("source_format" in weight_decode_info)
-            conditions.append(
-                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf", "fp_e4m3"])
+            conditions.append(weight_decode_info["source_format"]["format"] in
+                              ["uint", "int", "fp", "nf", "fp_e4m3"])
             # check source bits in [1, 2, 4, 8]
             conditions.append(weight_decode_info["source_format"]["bits"] in [1, 2, 4, 8])
             # check target format in ["float16", "int8"]
@@ -633,8 +633,8 @@ class MatmulTensorizationMMAWithDequantizeInfo(GPUScheduleRule):
             conditions = []
             # check source format in ["int", "fp", "nf"]
             conditions.append("source_format" in weight_decode_info)
-            conditions.append(
-                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf", "fp_e4m3"])
+            conditions.append(weight_decode_info["source_format"]["format"] in
+                              ["uint", "int", "fp", "nf", "fp_e4m3"])
             # check source bits in [1, 2, 4, 8]
             conditions.append(weight_decode_info["source_format"]["bits"] in [1, 2, 4, 8])
             # check target format in ["float16", "int8"]
@@ -1123,8 +1123,8 @@ class MatmulTensorizationMMAWithDequantizeInfo(GPUScheduleRule):
             conditions = []
             # check source format in ["int", "fp", "nf"]
             conditions.append("source_format" in weight_decode_info)
-            conditions.append(
-                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf", "fp_e4m3"])
+            conditions.append(weight_decode_info["source_format"]["format"] in
+                              ["uint", "int", "fp", "nf", "fp_e4m3"])
             # check source bits in [1, 2, 4, 8]
             conditions.append(weight_decode_info["source_format"]["bits"] in [1, 2, 4, 8])
             # check target format in ["float16", "int8"]

--- a/python/bitblas/gpu/matmul_mma_dequantize.py
+++ b/python/bitblas/gpu/matmul_mma_dequantize.py
@@ -127,7 +127,7 @@ class MatmulTensorizationMMAWithDequantizeInfo(GPUScheduleRule):
             # check source format in ["int", "fp", "nf"]
             conditions.append("source_format" in weight_decode_info)
             conditions.append(
-                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf"])
+                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf", "fp_e4m3"])
             # check source bits in [1, 2, 4, 8]
             conditions.append(weight_decode_info["source_format"]["bits"] in [1, 2, 4, 8])
             # check target format in ["float16", "int8"]
@@ -634,7 +634,7 @@ class MatmulTensorizationMMAWithDequantizeInfo(GPUScheduleRule):
             # check source format in ["int", "fp", "nf"]
             conditions.append("source_format" in weight_decode_info)
             conditions.append(
-                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf"])
+                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf", "fp_e4m3"])
             # check source bits in [1, 2, 4, 8]
             conditions.append(weight_decode_info["source_format"]["bits"] in [1, 2, 4, 8])
             # check target format in ["float16", "int8"]
@@ -1124,7 +1124,7 @@ class MatmulTensorizationMMAWithDequantizeInfo(GPUScheduleRule):
             # check source format in ["int", "fp", "nf"]
             conditions.append("source_format" in weight_decode_info)
             conditions.append(
-                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf"])
+                weight_decode_info["source_format"]["format"] in ["uint", "int", "fp", "nf", "fp_e4m3"])
             # check source bits in [1, 2, 4, 8]
             conditions.append(weight_decode_info["source_format"]["bits"] in [1, 2, 4, 8])
             # check target format in ["float16", "int8"]

--- a/python/bitblas/ops/general_matmul.py
+++ b/python/bitblas/ops/general_matmul.py
@@ -8,8 +8,7 @@ from bitblas.base.roller.arch.cuda import CUDA
 from typing import Any, List, Literal, Optional, Tuple, Union
 from .operator import Operator, TransformKind
 from .impl.matmul_dequantize_impl import (
-    select_implementation as weight_dequantize_implementation,
-)
+    select_implementation as weight_dequantize_implementation,)
 from .impl.matmul_impl import select_implementation as consistent_implementation
 from ..base.utils import tensor_replace_dp4a, tensor_remove_make_int4
 from bitblas.utils.target_detector import auto_detect_nvidia_target
@@ -110,36 +109,23 @@ class MatmulConfig:
 
     def __legalize_propagate(self, propagate):
         if isinstance(propagate, bool):
-            return (
-                TransformKind.IntraWarpTransform
-                if propagate
-                else TransformKind.NonTransform
-            )
+            return (TransformKind.IntraWarpTransform if propagate else TransformKind.NonTransform)
         elif isinstance(propagate, int):
             return TransformKind(propagate)
 
         return propagate
 
-    def __initialize_propagate(
-        self, propagate_a: Optional[TransformKind], propagate_b: Optional[TransformKind]
-    ):
+    def __initialize_propagate(self, propagate_a: Optional[TransformKind],
+                               propagate_b: Optional[TransformKind]):
         MICRO_KERNEL_SIZE = 16
-        if (
-            isinstance(self.M, int)
-            and (self.M % MICRO_KERNEL_SIZE) == 0
-            and (self.K % MICRO_KERNEL_SIZE) == 0
-        ):
+        if (isinstance(self.M, int) and (self.M % MICRO_KERNEL_SIZE) == 0 and
+            (self.K % MICRO_KERNEL_SIZE) == 0):
             object.__setattr__(self, "propagate_a", TransformKind.IntraWarpTransform)
         else:
             object.__setattr__(self, "propagate_a", TransformKind.NonTransform)
 
-        if (
-            self.M == 1
-            or (self.N % MICRO_KERNEL_SIZE) != 0
-            or (self.K % MICRO_KERNEL_SIZE) != 0
-            or isinstance(self.M, Tuple)
-            or (self.with_zeros and self.zeros_mode == "quantized")
-        ):
+        if (self.M == 1 or (self.N % MICRO_KERNEL_SIZE) != 0 or (self.K % MICRO_KERNEL_SIZE) != 0 or
+                isinstance(self.M, Tuple) or (self.with_zeros and self.zeros_mode == "quantized")):
             object.__setattr__(self, "propagate_a", TransformKind.NonTransform)
             object.__setattr__(self, "propagate_b", TransformKind.NonTransform)
         else:
@@ -164,10 +150,7 @@ class MatmulConfig:
     def __initialize_fast_decoding(self, fast_decoding: Optional[bool]):
         if fast_decoding is not None:
             object.__setattr__(self, "fast_decoding", fast_decoding)
-        elif (
-            "int" not in self.W_dtype
-            or self.W_dtype == self.A_dtype
-        ):
+        elif ("int" not in self.W_dtype or self.W_dtype == self.A_dtype):
             object.__setattr__(self, "fast_decoding", False)
         else:
             object.__setattr__(self, "fast_decoding", True)
@@ -186,12 +169,8 @@ class MatmulConfig:
         object.__setattr__(self, "M", self.__legalize_dynamic_symbolic(self.M))
 
         # set propagate_a and propagate_b to default value if it is None
-        object.__setattr__(
-            self, "propagate_a", self.__legalize_propagate(self.propagate_a)
-        )
-        object.__setattr__(
-            self, "propagate_b", self.__legalize_propagate(self.propagate_b)
-        )
+        object.__setattr__(self, "propagate_a", self.__legalize_propagate(self.propagate_a))
+        object.__setattr__(self, "propagate_b", self.__legalize_propagate(self.propagate_b))
 
         # This is hack to legalize propagate_a and b
         # TODO(lei): should be removed in the future when tc+br template is ready.
@@ -214,10 +193,10 @@ class MatmulConfig:
             object.__setattr__(self, "with_zeros", False)
 
         if self.A_dtype == self.W_dtype and self.W_dtype in [
-            "float16",
-            "int8",
-            "e4m3_float8",
-            "e5m2_float8",
+                "float16",
+                "int8",
+                "e4m3_float8",
+                "e5m2_float8",
         ]:
             object.__setattr__(self, "storage_dtype", self.W_dtype)
 
@@ -260,9 +239,8 @@ class Matmul(Operator):
         if target is None:
             target = auto_detect_nvidia_target()
             logger.info(f"Auto detected target: {target}")
-        assert (
-            config.A_dtype in self.BITBLAS_TRICK_DTYPE_MAP
-        ), f"Unsupported input dtype {config.A_dtype}"
+        assert (config.A_dtype
+                in self.BITBLAS_TRICK_DTYPE_MAP), f"Unsupported input dtype {config.A_dtype}"
         source_format, bit = self.BITBLAS_TRICK_DTYPE_MAP[config.W_dtype]
 
         self.source_format = source_format
@@ -283,8 +261,7 @@ class Matmul(Operator):
         if isinstance(self.M, Tuple):
             self.dynamic_range = {"m": self.M}
             self.prim_func_mod["main"] = self.prim_func_mod["main"].with_attrs(
-                {"opt_shapes": self.dynamic_range}
-            )
+                {"opt_shapes": self.dynamic_range})
         else:
             self.dynamic_range = None
 
@@ -393,9 +370,7 @@ class Matmul(Operator):
 
     def _build_default_module(self, target: Target):
         try:
-            self.optimized_func = self.apply_default_schedule(
-                self.prim_func_mod, target
-            )
+            self.optimized_func = self.apply_default_schedule(self.prim_func_mod, target)
         except Exception:
             self.optimized_func = None
             logger.warning(
@@ -446,9 +421,7 @@ class Matmul(Operator):
         return code
 
     def retrieve_weight_shape(self):
-        return [
-            int(i) for i in self.prim_func.buffer_map[self.prim_func.params[1]].shape
-        ]
+        return [int(i) for i in self.prim_func.buffer_map[self.prim_func.params[1]].shape]
 
     def transform_weight(self, weight, scale=None, zeros=None, bias=None):
         """
@@ -480,7 +453,7 @@ class Matmul(Operator):
         if source_format == "int":
             assert not self.with_scaling, "scale should be False for int source format"
             assert not self.with_zeros, "zeros should be False for int source format"
-            maxq = 2 ** (bit - 1)
+            maxq = 2**(bit - 1)
             # Clamp weight values to be within the quantizable range and adjust
             weight = torch.clamp(weight, -maxq, maxq).int() + maxq
         elif source_format in ["fp_e5m2", "fp_e4m3"]:
@@ -493,8 +466,7 @@ class Matmul(Operator):
         np_storage_dtype = getattr(np, self.storage_dtype)
 
         weight = general_compress(
-            weight.cpu().numpy(), source_bits=bit, storage_dtype=np_storage_dtype
-        )
+            weight.cpu().numpy(), source_bits=bit, storage_dtype=np_storage_dtype)
 
         weight = torch.from_numpy(weight).cuda().contiguous()
 
@@ -520,9 +492,7 @@ class Matmul(Operator):
                 raise ValueError(
                     f"Input size {input_tensor.numel()} is larger than the workspace size {WORKSPACE_SIZE}, please increase the workspace size."
                 )
-            self.ladder_permutate_a._forward_from_prebuild_lib(
-                input_tensor, self.workspace
-            )
+            self.ladder_permutate_a._forward_from_prebuild_lib(input_tensor, self.workspace)
             return self.workspace
         return input_tensor
 
@@ -530,14 +500,13 @@ class Matmul(Operator):
         args = []
         args.append(self.transform_input(A))
         args.append(W)
-        
+
         if self.lut is not None:
             args.append(self.lut)
 
         if output is None:
             output = torch.empty(
-                A.shape[:-1] + (self.N,), dtype=self.torch_output_dtype, device=A.device
-            )
+                A.shape[:-1] + (self.N,), dtype=self.torch_output_dtype, device=A.device)
         if scale is not None:
             args.append(scale)
         if zeros is not None:

--- a/python/bitblas/ops/general_matmul.py
+++ b/python/bitblas/ops/general_matmul.py
@@ -242,10 +242,9 @@ class Matmul(Operator):
         "int1": ("int", 1),
         "uint1": ("uint", 1),
         "nf4": ("nf", 4),
-        "fp8_e5m2": ("fp", 8),
         "fp4_e2m1": ("fp", 4),
-        "e4m3_float8": ("fp", 8),  # "e4m3_float8" is a trick for "float8_e4m3fn"
-        "e5m2_float8": ("fp", 8),
+        "e4m3_float8": ("fp_e4m3", 8),  # "e4m3_float8" is a trick for "float8_e4m3fn"
+        "e5m2_float8": ("fp_e5m2", 8),
     }
 
     def __init__(
@@ -484,6 +483,9 @@ class Matmul(Operator):
             maxq = 2 ** (bit - 1)
             # Clamp weight values to be within the quantizable range and adjust
             weight = torch.clamp(weight, -maxq, maxq).int() + maxq
+        elif source_format in ["fp_e5m2", "fp_e4m3"]:
+            weight = weight.view(torch.int8)
+            weight = weight.int()
         else:
             # For non-integer formats, simply convert weights to integers
             weight = weight.int()

--- a/python/bitblas/ops/impl/matmul_dequantize_impl.py
+++ b/python/bitblas/ops/impl/matmul_dequantize_impl.py
@@ -92,8 +92,7 @@ def matmul_nt_dequantize_b(
             w = _tir_u32_to_f4_to_f16(
                 bit, B[n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
         elif source_format == "fp_e4m3":
-            w = _tir_u8_to_f8_e4m3_to_f16(
-                bit, B[n, k], dtype=in_dtype)
+            w = _tir_u8_to_f8_e4m3_to_f16(bit, B[n, k], dtype=in_dtype)
         elif source_format == "nf":
             w = LUT[_tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
                 bit,
@@ -268,8 +267,7 @@ def matmul_nt_dequantize_b_propagate_b(
                 dtype=in_dtype,
             )
         elif source_format == "fp_e4m3":
-            w = _tir_u8_to_f8_e4m3_to_f16(
-                bit, B_reindex[n, k], dtype=in_dtype)
+            w = _tir_u8_to_f8_e4m3_to_f16(bit, B_reindex[n, k], dtype=in_dtype)
         elif source_format == "nf":
             w = LUT[_tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
                 bit,
@@ -457,8 +455,7 @@ def matmul_nt_dequantize_b_propagate_a_propagate_b(
                 dtype=in_dtype,
             )
         elif source_format == "fp_e4m3":
-            w = _tir_u8_to_f8_e4m3_to_f16(
-                bit, B_reindex[n, k], dtype=in_dtype)
+            w = _tir_u8_to_f8_e4m3_to_f16(bit, B_reindex[n, k], dtype=in_dtype)
         elif source_format == "nf":
             w = LUT[_tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
                 bit,

--- a/python/bitblas/ops/impl/matmul_dequantize_impl.py
+++ b/python/bitblas/ops/impl/matmul_dequantize_impl.py
@@ -11,6 +11,7 @@ from bitblas.quantization import (
     _tir_packed_to_signed_convert,
     _tir_packed_to_unsigned_convert,
     _tir_u32_to_f4_to_f16,
+    _tir_u8_to_f8_e4m3_to_f16,
     _tir_packed_to_unsigned_convert_with_zeros,
 )
 
@@ -58,14 +59,17 @@ def matmul_nt_dequantize_b(
             dtype=storage_dtype,
         )
 
-    Dequantize_qzeros = te.compute(
-        (K // group_size, N),
-        qzeros_dequantize,
-        name="Dequantize_zeros",
-    )
+    Dequantize_qzeros = None
+    if with_zeros and zeros_mode == "quantized":
+        Dequantize_qzeros = te.compute(
+            (K // group_size, N),
+            qzeros_dequantize,
+            name="Dequantize_zeros",
+        )
 
     def decode_func(n, k):
         if with_zeros and zeros_mode == "quantized":
+            assert Dequantize_qzeros is not None, "Dequantize_zeros is None"
             w = _tir_packed_to_unsigned_convert_with_zeros(storage_type, storage_nbit)(
                 bit,
                 B[n, k // n_float_per_elem],
@@ -87,6 +91,9 @@ def matmul_nt_dequantize_b(
         elif source_format == "fp":
             w = _tir_u32_to_f4_to_f16(
                 bit, B[n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
+        elif source_format == "fp_e4m3":
+            w = _tir_u8_to_f8_e4m3_to_f16(
+                bit, B[n, k], dtype=in_dtype)
         elif source_format == "nf":
             w = LUT[_tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
                 bit,
@@ -260,6 +267,9 @@ def matmul_nt_dequantize_b_propagate_b(
                 k % n_float_per_elem,
                 dtype=in_dtype,
             )
+        elif source_format == "fp_e4m3":
+            w = _tir_u8_to_f8_e4m3_to_f16(
+                bit, B_reindex[n, k], dtype=in_dtype)
         elif source_format == "nf":
             w = LUT[_tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
                 bit,
@@ -446,6 +456,9 @@ def matmul_nt_dequantize_b_propagate_a_propagate_b(
                 k % n_float_per_elem,
                 dtype=in_dtype,
             )
+        elif source_format == "fp_e4m3":
+            w = _tir_u8_to_f8_e4m3_to_f16(
+                bit, B_reindex[n, k], dtype=in_dtype)
         elif source_format == "nf":
             w = LUT[_tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
                 bit,

--- a/python/bitblas/quantization/__init__.py
+++ b/python/bitblas/quantization/__init__.py
@@ -5,6 +5,7 @@ from .quantization import (
     _tir_packed_to_signed_convert,  # noqa: F401
     _tir_packed_to_unsigned_convert,  # noqa: F401
     _tir_u32_to_f4_to_f16,  # noqa: F401
+    _tir_u8_to_f8_e4m3_to_f16,  # noqa: F401
     _tir_packed_to_unsigned_convert_with_zeros,  # noqa: F401
 )
 

--- a/python/bitblas/quantization/quantization.py
+++ b/python/bitblas/quantization/quantization.py
@@ -138,6 +138,22 @@ def _tir_u32_to_f4_to_f16(nbit: int, val: tir.PrimExpr, pos: tir.PrimExpr, dtype
                               (e_f16 | (s << tir.const(5, "uint32"))) << tir.const(10, "uint32"))
     return tir.Select(e_f4 == tir.const(0, "uint32"), tir.const(0, "float16"), val_f16)
 
+def _tir_u8_to_f8_e4m3_to_f16(nbit: int, val: tir.PrimExpr, dtype: str):
+    assert nbit == 8
+    assert dtype == "float16"
+    s_f16 = (val >> tir.const(7, "int16")) << tir.const(15, "int16")
+    offset = tir.Select(
+        s_f16 == 0,
+        tir.const(8192, "int16"),
+        tir.const(-8192, "int16")
+    )
+    e_f16 = ((val << tir.const(7, "int16")) + offset)
+    return tir.reinterpret("float16", s_f16 | e_f16)
+
+def _tir_u8_to_f8_e5m2_to_f16(nbit: int, val: tir.PrimExpr, dtype: str):
+    assert nbit == 8
+    assert dtype == "float16"
+    return tir.reinterpret("e5m2_float8", val).astype("float16")
 
 def _tir_packed_to_signed_convert(storage_type="uint", storage_nbit=8):
     storage_dtype = storage_type + str(storage_nbit)

--- a/python/bitblas/quantization/quantization.py
+++ b/python/bitblas/quantization/quantization.py
@@ -138,22 +138,21 @@ def _tir_u32_to_f4_to_f16(nbit: int, val: tir.PrimExpr, pos: tir.PrimExpr, dtype
                               (e_f16 | (s << tir.const(5, "uint32"))) << tir.const(10, "uint32"))
     return tir.Select(e_f4 == tir.const(0, "uint32"), tir.const(0, "float16"), val_f16)
 
+
 def _tir_u8_to_f8_e4m3_to_f16(nbit: int, val: tir.PrimExpr, dtype: str):
     assert nbit == 8
     assert dtype == "float16"
     s_f16 = (val >> tir.const(7, "int16")) << tir.const(15, "int16")
-    offset = tir.Select(
-        s_f16 == 0,
-        tir.const(8192, "int16"),
-        tir.const(-8192, "int16")
-    )
+    offset = tir.Select(s_f16 == 0, tir.const(8192, "int16"), tir.const(-8192, "int16"))
     e_f16 = ((val << tir.const(7, "int16")) + offset)
     return tir.reinterpret("float16", s_f16 | e_f16)
+
 
 def _tir_u8_to_f8_e5m2_to_f16(nbit: int, val: tir.PrimExpr, dtype: str):
     assert nbit == 8
     assert dtype == "float16"
     return tir.reinterpret("e5m2_float8", val).astype("float16")
+
 
 def _tir_packed_to_signed_convert(storage_type="uint", storage_nbit=8):
     storage_dtype = storage_type + str(storage_nbit)
@@ -189,6 +188,7 @@ def _tir_packed_to_unsigned_convert_with_zeros(storage_type="uint", storage_nbit
 
     return f_convert
 
+
 def _tir_packed_int_to_int_convert(storage_type="uint", storage_nbit=8):
     storage_dtype = storage_type + str(storage_nbit)
 
@@ -200,5 +200,6 @@ def _tir_packed_int_to_int_convert(storage_type="uint", storage_nbit=8):
             dtype, (unextended << tir.const(32 - nbit, "int32")) >> tir.const(32 - nbit, "int32"))
 
     return f_convert
+
 
 # fmt: on

--- a/testing/python/operators/test_general_matmul_fp8.py
+++ b/testing/python/operators/test_general_matmul_fp8.py
@@ -5,10 +5,10 @@ import bitblas
 from bitblas import MatmulConfig, Matmul
 import logging
 from bitblas import set_log_level
-
+            
 set_log_level(logging.DEBUG)
 
-
+# TODO(lei): should add requirements for cuda and sm version
 @pytest.mark.parametrize(
     "M,N,K,A_dtype,W_dtype,accum_dtype,out_dtype,layout,with_bias,group_size,with_scaling,with_zeros,zeros_mode",
     [
@@ -71,6 +71,92 @@ def test_matmul_torch_forward(M, N, K, A_dtype, W_dtype, accum_dtype, out_dtype,
     new_torch_b = matmul.transform_weight(torch_b)
     bitblas_out = matmul(torch_a, new_torch_b)
     print("bitblas_out", bitblas_out)
+    
+# TODO(lei): should add requirements for cuda and sm version
+@pytest.mark.parametrize(
+    "M,N,K,A_dtype,W_dtype,accum_dtype,out_dtype,layout,with_bias,group_size,with_scaling,with_zeros,zeros_mode",
+    [
+        (1, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, None, None, None, None),
+        (1024, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, None, None, None, None),
+        (1, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, 32, True, None, None),
+        (1024, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, 32, True, None, None),
+    ],
+)
+def test_matmul_torch_forward_weight_dequantize(M, N, K, A_dtype, W_dtype, accum_dtype, out_dtype, layout, with_bias,
+                              group_size, with_scaling, with_zeros, zeros_mode):
+    import torch
+    torch.random.manual_seed(0)
+
+    matmul_config = MatmulConfig(
+        M=M,
+        N=N,
+        K=K,
+        A_dtype=A_dtype,
+        W_dtype=W_dtype,
+        accum_dtype=accum_dtype,
+        out_dtype=out_dtype,
+        layout=layout,
+        with_bias=with_bias,
+        group_size=group_size,
+        with_scaling=with_scaling,
+        with_zeros=with_zeros,
+        zeros_mode=zeros_mode,
+        propagate_a=False,
+        propagate_b=False,
+    )
+    matmul = Matmul(config=matmul_config, enable_tuning=False)
+    print(matmul.src_name)
+    input_shape = (M, K)
+    weight_shape = (N, K) if layout == "nt" else (K, N)
+    
+    def map_torch_type(intype):
+        
+        typemap = {
+            'e4m3_float8': torch.float8_e4m3fn,
+            'e5m2_float8': torch.float8_e5m2,
+        }
+        if intype in typemap:
+            return typemap[intype]
+        else:
+            return getattr(torch, intype)
+
+    numpytype_a = map_torch_type(A_dtype)
+    numpytype_b = map_torch_type(W_dtype)
+    numpytype_c = map_torch_type(out_dtype)
+    
+    torch_a = torch.rand(M*K).uniform_(-1, 1).reshape(input_shape).type(numpytype_a).cuda()
+    torch_b = torch.rand(N*K).uniform_(-1, 1).reshape(weight_shape).type(numpytype_b).cuda()
+    
+    torch_fp16_a = torch_a.to(torch.float16)
+    torch_fp16_b = torch_b.t().to(torch.float16) if layout == "nt" else torch_b.to(torch.float16)
+    scale_tensor = None
+    if with_scaling:
+        if group_size is None:
+            group_size = -1
+        if group_size == -1:
+            group_size = K
+        scale_tensor = torch.rand(N * K // group_size).uniform_(-4, 4).reshape([N, K // group_size]).type(torch.float16).cuda()
+        # scale_tensor = torch.ones([N, K // group_size]).type(torch.float16).cuda()
+        rescale_b = torch.zeros_like(torch_b).type(torch.float16)
+        for i in range(K):
+            rescale_b[:, i] = torch_b.to(torch.float16)[:, i] * scale_tensor[:, i // group_size]
+        torch_fp16_b = rescale_b.t().to(torch.float16) if layout == "nt" else rescale_b.to(torch.float16)
+        
+    ref_out = torch.matmul(torch_fp16_a, torch_fp16_b)
+    ref_out = ref_out.to(numpytype_c)
+    
+        
+    permuted_inputs = []
+    permuted_inputs.append(torch_a)
+    permuted_inputs.append(matmul.transform_weight(torch_b))
+    if with_scaling:
+        permuted_inputs.append(scale_tensor)
+    bitblas_out = matmul(*permuted_inputs)
+    
+    print("torch_ref_out", ref_out)
+    print("bitblas_out", bitblas_out)
+
+    torch.testing.assert_allclose(ref_out, bitblas_out, rtol=1e-2, atol=1e-2)
 
 # fmt: on
 if __name__ == "__main__":

--- a/testing/python/operators/test_general_matmul_fp8.py
+++ b/testing/python/operators/test_general_matmul_fp8.py
@@ -5,21 +5,22 @@ import bitblas
 from bitblas import MatmulConfig, Matmul
 import logging
 from bitblas import set_log_level
-            
+
 set_log_level(logging.DEBUG)
+
 
 # TODO(lei): should add requirements for cuda and sm version
 @pytest.mark.parametrize(
     "M,N,K,A_dtype,W_dtype,accum_dtype,out_dtype,layout,with_bias,group_size,with_scaling,with_zeros,zeros_mode",
     [
-        (1, 1024, 1024, "e4m3_float8", "e4m3_float8", "float32", "float32", "nt", None, None, None, None,
-         None),
-        (1024, 1024, 1024, "e4m3_float8", "e4m3_float8", "float32", "float32", "nt", None, None, None, None,
-         None),
-        (1, 1024, 1024, "e5m2_float8", "e5m2_float8", "float32", "float32", "nt", None, None, None, None,
-         None),
-        (1024, 1024, 1024, "e5m2_float8", "e5m2_float8", "float32", "float32", "nt", None, None, None, None,
-         None),
+        (1, 1024, 1024, "e4m3_float8", "e4m3_float8", "float32", "float32", "nt", None, None, None,
+         None, None),
+        (1024, 1024, 1024, "e4m3_float8", "e4m3_float8", "float32", "float32", "nt", None, None,
+         None, None, None),
+        (1, 1024, 1024, "e5m2_float8", "e5m2_float8", "float32", "float32", "nt", None, None, None,
+         None, None),
+        (1024, 1024, 1024, "e5m2_float8", "e5m2_float8", "float32", "float32", "nt", None, None,
+         None, None, None),
     ],
 )
 def test_matmul_torch_forward(M, N, K, A_dtype, W_dtype, accum_dtype, out_dtype, layout, with_bias,
@@ -46,9 +47,9 @@ def test_matmul_torch_forward(M, N, K, A_dtype, W_dtype, accum_dtype, out_dtype,
 
     input_shape = (M, K)
     weight_shape = (N, K) if layout == "nt" else (K, N)
-    
+
     def map_torch_type(intype):
-        
+
         typemap = {
             'e4m3_float8': torch.float8_e4m3fn,
             'e5m2_float8': torch.float8_e5m2,
@@ -61,29 +62,37 @@ def test_matmul_torch_forward(M, N, K, A_dtype, W_dtype, accum_dtype, out_dtype,
     numpytype_a = map_torch_type(A_dtype)
     numpytype_b = map_torch_type(W_dtype)
     numpytype_c = map_torch_type(out_dtype)
-    
-    torch_a = torch.rand(M*K).uniform_(-5, 5).reshape(input_shape).type(numpytype_a).cuda()
-    torch_b = torch.rand(N*K).uniform_(-5, 5).reshape(weight_shape).type(numpytype_b).cuda()
-    ref_out = torch.matmul(torch_a.to(torch.float32), torch_b.t().to(torch.float32)) if layout == "nt" else torch.matmul(torch_a.to(torch.float32), torch_b.to(torch.float32))
+
+    torch_a = torch.rand(M * K).uniform_(-5, 5).reshape(input_shape).type(numpytype_a).cuda()
+    torch_b = torch.rand(N * K).uniform_(-5, 5).reshape(weight_shape).type(numpytype_b).cuda()
+    ref_out = torch.matmul(torch_a.to(torch.float32),
+                           torch_b.t().to(torch.float32)) if layout == "nt" else torch.matmul(
+                               torch_a.to(torch.float32), torch_b.to(torch.float32))
     ref_out = ref_out.to(numpytype_c)
-    
+
     print("torch_ref_out", ref_out)
     new_torch_b = matmul.transform_weight(torch_b)
     bitblas_out = matmul(torch_a, new_torch_b)
     print("bitblas_out", bitblas_out)
-    
+
+
 # TODO(lei): should add requirements for cuda and sm version
 @pytest.mark.parametrize(
     "M,N,K,A_dtype,W_dtype,accum_dtype,out_dtype,layout,with_bias,group_size,with_scaling,with_zeros,zeros_mode",
     [
-        (1, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, None, None, None, None),
-        (1024, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, None, None, None, None),
-        (1, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, 32, True, None, None),
-        (1024, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, 32, True, None, None),
+        (1, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, None, None,
+         None, None),
+        (1024, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, None, None,
+         None, None),
+        (1, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, 32, True, None,
+         None),
+        (1024, 1024, 1024, "float16", "e4m3_float8", "float16", "float16", "nt", None, 32, True,
+         None, None),
     ],
 )
-def test_matmul_torch_forward_weight_dequantize(M, N, K, A_dtype, W_dtype, accum_dtype, out_dtype, layout, with_bias,
-                              group_size, with_scaling, with_zeros, zeros_mode):
+def test_matmul_torch_forward_weight_dequantize(M, N, K, A_dtype, W_dtype, accum_dtype, out_dtype,
+                                                layout, with_bias, group_size, with_scaling,
+                                                with_zeros, zeros_mode):
     import torch
     torch.random.manual_seed(0)
 
@@ -108,9 +117,9 @@ def test_matmul_torch_forward_weight_dequantize(M, N, K, A_dtype, W_dtype, accum
     print(matmul.src_name)
     input_shape = (M, K)
     weight_shape = (N, K) if layout == "nt" else (K, N)
-    
+
     def map_torch_type(intype):
-        
+
         typemap = {
             'e4m3_float8': torch.float8_e4m3fn,
             'e5m2_float8': torch.float8_e5m2,
@@ -123,10 +132,10 @@ def test_matmul_torch_forward_weight_dequantize(M, N, K, A_dtype, W_dtype, accum
     numpytype_a = map_torch_type(A_dtype)
     numpytype_b = map_torch_type(W_dtype)
     numpytype_c = map_torch_type(out_dtype)
-    
-    torch_a = torch.rand(M*K).uniform_(-1, 1).reshape(input_shape).type(numpytype_a).cuda()
-    torch_b = torch.rand(N*K).uniform_(-1, 1).reshape(weight_shape).type(numpytype_b).cuda()
-    
+
+    torch_a = torch.rand(M * K).uniform_(-1, 1).reshape(input_shape).type(numpytype_a).cuda()
+    torch_b = torch.rand(N * K).uniform_(-1, 1).reshape(weight_shape).type(numpytype_b).cuda()
+
     torch_fp16_a = torch_a.to(torch.float16)
     torch_fp16_b = torch_b.t().to(torch.float16) if layout == "nt" else torch_b.to(torch.float16)
     scale_tensor = None
@@ -135,28 +144,30 @@ def test_matmul_torch_forward_weight_dequantize(M, N, K, A_dtype, W_dtype, accum
             group_size = -1
         if group_size == -1:
             group_size = K
-        scale_tensor = torch.rand(N * K // group_size).uniform_(-4, 4).reshape([N, K // group_size]).type(torch.float16).cuda()
+        scale_tensor = torch.rand(N * K // group_size).uniform_(-4, 4).reshape(
+            [N, K // group_size]).type(torch.float16).cuda()
         # scale_tensor = torch.ones([N, K // group_size]).type(torch.float16).cuda()
         rescale_b = torch.zeros_like(torch_b).type(torch.float16)
         for i in range(K):
             rescale_b[:, i] = torch_b.to(torch.float16)[:, i] * scale_tensor[:, i // group_size]
-        torch_fp16_b = rescale_b.t().to(torch.float16) if layout == "nt" else rescale_b.to(torch.float16)
-        
+        torch_fp16_b = rescale_b.t().to(torch.float16) if layout == "nt" else rescale_b.to(
+            torch.float16)
+
     ref_out = torch.matmul(torch_fp16_a, torch_fp16_b)
     ref_out = ref_out.to(numpytype_c)
-    
-        
+
     permuted_inputs = []
     permuted_inputs.append(torch_a)
     permuted_inputs.append(matmul.transform_weight(torch_b))
     if with_scaling:
         permuted_inputs.append(scale_tensor)
     bitblas_out = matmul(*permuted_inputs)
-    
+
     print("torch_ref_out", ref_out)
     print("bitblas_out", bitblas_out)
 
     torch.testing.assert_allclose(ref_out, bitblas_out, rtol=1e-2, atol=1e-2)
+
 
 # fmt: on
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request primarily focuses on expanding the functionality of the existing codebase to include support for new formats and simplifying the existing code. The most significant changes include the addition of new formats (FP8_E4M3, FP_E5M2) in the `check_weight_decode_info` function, simplification of code in `general_matmul.py`, and the addition of new conversion functions in `quantization.py`.

Addition of new formats:

* [`python/bitblas/gpu/gemv_dequantize.py`](diffhunk://#diff-17852446656170f284e0d9851855b4d45fe4b29885de47b60c542a88bc8d6592L52-R53): Updated the `check_weight_decode_info` function to include the new formats "fp_e5m2" and "fp_e4m3" in the list of acceptable formats. [[1]](diffhunk://#diff-17852446656170f284e0d9851855b4d45fe4b29885de47b60c542a88bc8d6592L52-R53) [[2]](diffhunk://#diff-17852446656170f284e0d9851855b4d45fe4b29885de47b60c542a88bc8d6592L216-R217)
* [`python/bitblas/gpu/matmul_mma_dequantize.py`](diffhunk://#diff-038c96b940c142e48d4a935c99f3322af364a8c4d9a6e96396335331ee9ef58eL129-R130): Similar changes were made in this file to include the new format "fp_e4m3". [[1]](diffhunk://#diff-038c96b940c142e48d4a935c99f3322af364a8c4d9a6e96396335331ee9ef58eL129-R130) [[2]](diffhunk://#diff-038c96b940c142e48d4a935c99f3322af364a8c4d9a6e96396335331ee9ef58eL636-R637) [[3]](diffhunk://#diff-038c96b940c142e48d4a935c99f3322af364a8c4d9a6e96396335331ee9ef58eL1126-R1127)

Code simplification:

* [`python/bitblas/ops/general_matmul.py`](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L11-R11): Multiple changes were made in this file to simplify the code. These changes primarily involve reducing the number of lines of code by combining statements and removing unnecessary parentheses. [[1]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L11-R11) [[2]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L113-R128) [[3]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L167-R153) [[4]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L189-R173) [[5]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L245-R226) [[6]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L264-R243) [[7]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L287-R264) [[8]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L397-R373) [[9]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L450-R424) [[10]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715R459-R469) [[11]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L521-R495) [[12]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L537-R509)

Addition of new conversion functions:

* [`python/bitblas/quantization/quantization.py`](diffhunk://#diff-503bb115fee1e2a4e550c48b1e81d65e691d4c53bc73ed562cb781cce8a9022dR142-R156): New conversion functions `_tir_u8_to_f8_e4m3_to_f16` and `_tir_u8_to_f8_e5m2_to_f16` were added to support the new formats. [[1]](diffhunk://#diff-503bb115fee1e2a4e550c48b1e81d65e691d4c53bc73ed562cb781cce8a9022dR142-R156) [[2]](diffhunk://#diff-503bb115fee1e2a4e550c48b1e81d65e691d4c53bc73ed562cb781cce8a9022dR191)