### PR TITLE
[Feature] Enhancing MatmulOps with Splitk Support

### DIFF
--- a/python/bitblas/base/roller/__init__.py
+++ b/python/bitblas/base/roller/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 from .node import PrimFuncNode  # noqa: F401
+from .rasterization import NoRasterization, Rasterization2DRow, Rasterization2DColumn  # noqa: F401
 from .hint import Hint  # noqa: F401
 from .policy import DefaultPolicy, TensorCorePolicy  # noqa: F401
 from .arch import TileDevice, CUDA  # noqa: F401

--- a/python/bitblas/base/roller/hint.py
+++ b/python/bitblas/base/roller/hint.py
@@ -6,6 +6,7 @@ from . import PrimFuncNode
 import numpy as np
 from .rasterization import *
 
+
 class TensorCoreExtraConfig:
     """
     This class is used to store extra information for tensorcore

--- a/python/bitblas/base/roller/hint.py
+++ b/python/bitblas/base/roller/hint.py
@@ -228,7 +228,8 @@ class Hint(object):
     def complete_config(self, node: PrimFuncNode):
         # analysis pass context, for int8 mma, we should merge static shared memory
         merge_static_smem = False
-        if self.use_tc and self.intrin_info.in_dtype == "int8":
+        # int32 and float32 accum may take too much shared memory
+        if self.use_tc and self.intrin_info.out_dtype in ["float32", "int32"]:
             merge_static_smem = True
         self.pass_context = {"tir.merge_static_smem": merge_static_smem}
         return self

--- a/python/bitblas/base/roller/hint.py
+++ b/python/bitblas/base/roller/hint.py
@@ -211,6 +211,12 @@ class Hint(object):
             setattr(self, k, v)
         return self
 
+    def tensorcore_legalization(self):
+        # only keep the last 2 axes for tensorcore
+        self.warp = self.warp[-2:]
+        self.block = self.block[-2:]
+        return self
+
     @property
     def raxis_order(self) -> List[int]:
         if self._raxis_order != []:

--- a/python/bitblas/base/roller/policy/tensorcore.py
+++ b/python/bitblas/base/roller/policy/tensorcore.py
@@ -307,6 +307,7 @@ class TensorCorePolicy(DefaultPolicy):
         codegen_dict.vectorize = self._plan_vectorize(self.prim_func_node, td, block_size)
         codegen_dict.arch = self.arch
         codegen_dict.opt_shapes = self.prim_func_node.get_tag("opt_shapes")
+        codegen_dict.tensorcore_legalization()
         return codegen_dict
 
     def plan_rasterization(self, td: TileDict):

--- a/python/bitblas/base/roller/policy/tensorcore.py
+++ b/python/bitblas/base/roller/policy/tensorcore.py
@@ -297,6 +297,8 @@ class TensorCorePolicy(DefaultPolicy):
         intrin_info = node.get_tag("intrin_info")
         if intrin_info:
             codegen_dict.intrin_info = IntrinInfo(**intrin_info)
+            if intrin_info["out_dtype"] in ["float32"]:
+                codegen_dict.shared_scope = "shared.dyn"
         # smem capacity
         if td.smem_cost > self.arch.smem_cap:
             codegen_dict.shared_scope = "shared.dyn"

--- a/python/bitblas/gpu/intrin/lop3.py
+++ b/python/bitblas/gpu/intrin/lop3.py
@@ -1553,6 +1553,32 @@ TensorIntrin.register(
     ),
 )
 
+LOP3_FAST_DECODE_INT1_TO_INT8_TO_FP16_L8_INTRIN = ("lop3_fast_decode_i1_to_int8_to_f16_l8_")
+TensorIntrin.register(
+    LOP3_FAST_DECODE_INT1_TO_INT8_TO_FP16_L8_INTRIN,
+    *get_fast_decode_intrin(
+        source_bit=1,
+        storage_dtype="int8",
+        source_format="int",
+        target_dtype="float16",
+        loops_extent=8,
+    ),
+)
+
+LOP3_FAST_DECODE_INT1_TO_INT8_TO_FP16_L8_SCALE_INTRIN = (
+    "lop3_fast_decode_i1_to_int8_to_f16_l8_scale_")
+TensorIntrin.register(
+    LOP3_FAST_DECODE_INT1_TO_INT8_TO_FP16_L8_SCALE_INTRIN,
+    *get_fast_decode_intrin(
+        source_bit=1,
+        storage_dtype="int8",
+        source_format="int",
+        target_dtype="float16",
+        loops_extent=8,
+        with_scale=True,
+    ),
+)
+
 
 def get_lop3_intrin_group(
     out_dtype: Literal["float16", "int8"],

--- a/python/bitblas/gpu/intrin/lop3.py
+++ b/python/bitblas/gpu/intrin/lop3.py
@@ -1483,7 +1483,11 @@ LOP3_FAST_DECODE_INT2_TO_INT8_TO_INT8_L16_INTRIN = ("lop3_fast_decode_i2_to_int8
 TensorIntrin.register(
     LOP3_FAST_DECODE_INT2_TO_INT8_TO_INT8_L16_INTRIN,
     *get_fast_decode_intrin(
-        source_bit=2, source_format="int", storage_dtype="int8", target_dtype="int8", loops_extent=16),
+        source_bit=2,
+        source_format="int",
+        storage_dtype="int8",
+        target_dtype="int8",
+        loops_extent=16),
 )
 
 LOP3_FAST_DECODE_UINT1_TO_INT8_TO_INT8_L16_INTRIN = ("lop3_fast_decode_u1_to_int8_to_i8_l16_")
@@ -1497,9 +1501,12 @@ LOP3_FAST_DECODE_INT1_TO_INT8_TO_INT8_L16_INTRIN = ("lop3_fast_decode_i1_to_int8
 TensorIntrin.register(
     LOP3_FAST_DECODE_INT1_TO_INT8_TO_INT8_L16_INTRIN,
     *get_fast_decode_intrin(
-        source_bit=1, source_format="int", storage_dtype="int8", target_dtype="int8", loops_extent=16),
+        source_bit=1,
+        source_format="int",
+        storage_dtype="int8",
+        target_dtype="int8",
+        loops_extent=16),
 )
-
 
 LOP3_FAST_DECODE_INT4_TO_INT8_TO_FP16_L8_INTRIN = ("lop3_fast_decode_i4_to_int8_to_f16_l8_")
 TensorIntrin.register(

--- a/python/bitblas/gpu/matmul_analysis.py
+++ b/python/bitblas/gpu/matmul_analysis.py
@@ -17,10 +17,23 @@ from ..base.analysis import (
     get_reduction_blocks,
 )
 from tvm.target.target import Target
-from tvm.tir import IndexMap
+from tvm.tir import IndexMap, Var
+from tvm.tir.stmt_functor import pre_order_visit
 import logging
 
 logger = logging.getLogger(__name__)
+
+def collect_vars_from_expr(prim_expr):
+    vars = []
+
+    def callback(node):
+        if isinstance(node, Var):
+            vars.append(node)
+        return True
+
+    pre_order_visit(prim_expr, callback)
+
+    return vars
 
 
 def _is_one(x: PrimExpr) -> bool:
@@ -337,9 +350,16 @@ def get_index_map(block: tir.Block,
                 return True
         return False
 
+    def has_common_reduce(var: Var) -> bool:
+        vars = collect_vars_from_expr(var)
+        for v in vars:
+            if is_common_reduce(v):
+                return True
+        return False
+
     def check_last_trait(region: List[Range]):
         axes = get_ordered_axes(region)
-        return is_common_reduce(axes[-1])
+        return has_common_reduce(axes[-1])
 
     def infer_layout(layout: str, region: List[Range], kind: str = "A"):
         """
@@ -583,10 +603,18 @@ def get_tensorized_func_and_tags(
                     return True
             return False
 
+        def has_common_reduce(var: Var) -> bool:
+            vars = collect_vars_from_expr(var)
+            for v in vars:
+                if is_common_reduce(v):
+                    return True
+            return False
+        
         def check_last_trait(region: List[Range]):
             axes = get_ordered_axes(region)
-            return is_common_reduce(axes[-1])
+            return has_common_reduce(axes[-1])
 
+        
         intrin_info: dict = {}
         in_dtype, out_dtype = get_in_out_dtypes(block_stmt)
         intrin_info["in_dtype"] = in_dtype

--- a/python/bitblas/module/__init__.py
+++ b/python/bitblas/module/__init__.py
@@ -11,7 +11,7 @@ import torch.nn as nn
 
 logger = getLogger(__name__)
 
-from typing import List, Union
+from typing import List, Union, Optional
 
 from bitblas.cache import global_operator_cache, get_database_path
 from bitblas import Matmul, MatmulConfig
@@ -67,7 +67,7 @@ class Linear(nn.Module):
         opt_M: Union[int, List[int]] = opt_M,
         # performance related configs
         enable_tuning: bool = True,
-        fast_decoding: bool = True,
+        fast_decoding: Optional[bool] = None,
         propagate_b: bool = False,
     ):
         """

--- a/python/bitblas/ops/general_matmul.py
+++ b/python/bitblas/ops/general_matmul.py
@@ -5,14 +5,13 @@ from tvm.target import Target
 import operator
 from functools import reduce
 from bitblas.base.roller.arch.cuda import CUDA
-from typing import Any, List, Literal, Optional, Tuple, Union
-from .operator import Operator, TransformKind
+from typing import Any, Literal, Optional, Tuple, Union
+from .operator import Operator, TransformKind, OPExecutorCPU
 from .impl.matmul_dequantize_impl import (
     select_implementation as weight_dequantize_implementation,)
 from .impl.matmul_impl import select_implementation as consistent_implementation
 from ..base.utils import tensor_replace_dp4a, tensor_remove_make_int4
 from bitblas.utils.target_detector import auto_detect_nvidia_target
-from bitblas.utils.tensor_adapter import tvm_tensor_to_torch
 from dataclasses import dataclass
 from .ladder_permutate import LadderPermutate, LadderPermutateConfig
 from .lop3_permutate import LOP3Permutate, LOP3PermutateConfig
@@ -40,35 +39,6 @@ NATIVE_COMPUTE_PATTERNS = [
 
 def is_native_compute(A_dtype, W_dtype) -> bool:
     return (A_dtype, W_dtype) in NATIVE_COMPUTE_PATTERNS
-
-
-class OPExecutorCPU:
-
-    def __init__(self, operators: Optional[List[Operator]] = None):
-        if operators is None:
-            operators = []
-        self.operators = operators
-
-    def append(self, op):
-        self.operators.append(op)
-
-    def is_none(self):
-        return len(self.operators) == 0
-
-    def forward(self, weight):
-        inputs = [weight]
-        for op in self.operators:
-            inputs.append(tvm_tensor_to_torch(op.get_profile_tensors()[-1]).cpu())
-            inputs = [op.forward(*inputs)]
-        return inputs[-1]
-
-    def __call__(self, *args: Any, **kwds: Any) -> Any:
-        return self.forward(*args, **kwds)
-
-    @property
-    def size(self):
-        return len(self.operators)
-
 
 @dataclass(frozen=True)
 class MatmulConfig:
@@ -527,10 +497,12 @@ class Matmul(Operator):
         if self.dynamic_range is not None:
             m = reduce(operator.mul, A.shape[:-1], 1)
             args.append(m)
+        
+        stream = torch.cuda.current_stream()
 
         if self.lib is None:
             self._forward_from_torch_func(*args)
-        self._forward_from_prebuild_lib(*args)
+        self._forward_from_prebuild_lib(*args, stream=stream.cuda_stream)
 
         return output
 

--- a/python/bitblas/ops/general_matmul.py
+++ b/python/bitblas/ops/general_matmul.py
@@ -40,6 +40,7 @@ NATIVE_COMPUTE_PATTERNS = [
 def is_native_compute(A_dtype, W_dtype) -> bool:
     return (A_dtype, W_dtype) in NATIVE_COMPUTE_PATTERNS
 
+
 @dataclass(frozen=True)
 class MatmulConfig:
     M: Union[int, Tuple[int]] = None
@@ -497,7 +498,7 @@ class Matmul(Operator):
         if self.dynamic_range is not None:
             m = reduce(operator.mul, A.shape[:-1], 1)
             args.append(m)
-        
+
         stream = torch.cuda.current_stream()
 
         if self.lib is None:

--- a/python/bitblas/ops/general_matmul_splitk.py
+++ b/python/bitblas/ops/general_matmul_splitk.py
@@ -1,0 +1,191 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+from tvm.target import Target
+import operator
+from functools import reduce
+from typing import Any, Optional,  Union
+from .operator import TransformKind
+from .impl.matmul_splitk_impl import select_implementation as consistent_implementation
+from .impl.matmul_dequantize_splitk_impl import select_implementation as weight_dequantize_implementation
+from dataclasses import dataclass
+import logging
+import torch
+from .general_matmul import MatmulConfig, Matmul
+from .general_matmul import is_native_compute
+
+logger = logging.getLogger(__name__)
+
+WORKSPACE_SIZE = 1024 * 1024 * 256
+
+@dataclass(frozen=True)
+class MatmulConfigWithSplitK(MatmulConfig):
+    k_split: int = 1 # split K dimension
+
+
+class MatmulWithSplitK(Matmul):
+
+    def __init__(
+        self,
+        config: MatmulConfig,
+        name: str = "matmul",
+        target: Optional[Union[str, Target]] = None,
+        enable_tuning: bool = True,
+        from_database: bool = False,
+    ):
+        super().__init__(config, name, target, enable_tuning, from_database)
+
+    def _select_implementation(self):
+        # the major implementation
+        if is_native_compute(self.A_dtype, self.W_dtype):
+            return consistent_implementation(
+                SplitK=self.k_split,
+                M=self.M,
+                N=self.N,
+                K=self.K,
+                in_dtype=self.A_dtype,
+                out_dtype=self.out_dtype,
+                accum_dtype=self.accum_dtype,
+                with_bias=self.with_bias,
+                layout=self.layout,
+                propagate_a=self.propagate_a,
+                propagate_b=self.propagate_b,
+            )
+        else:
+            return weight_dequantize_implementation(
+                SplitK=self.k_split,
+                M=self.M,
+                N=self.N,
+                K=self.K,
+                in_dtype=self.A_dtype,
+                out_dtype=self.out_dtype,
+                accum_dtype=self.accum_dtype,
+                bit=self.bit,
+                storage_dtype=self.storage_dtype,
+                source_format=self.source_format,
+                with_scaling=self.with_scaling,
+                with_zeros=self.with_zeros,
+                group_size=self.group_size,
+                fast_decoding=self.fast_decoding,
+                with_bias=self.with_bias,
+                layout=self.layout,
+                zeros_mode=self.zeros_mode,
+                propagate_a=self.propagate_a,
+                propagate_b=self.propagate_b,
+            )
+
+    def retrieve_weight_shape(self):
+        return [int(i) for i in self.prim_func.buffer_map[self.prim_func.params[1]].shape]
+
+    def transform_weight(self, weight, scale=None, zeros=None, bias=None):
+        """
+        Transforms the given weight tensor based on the specified quantization parameters and
+        returns the transformed weight along with optional scale, zeros, and bias.
+
+        Parameters:
+        - weight: The input weight tensor to be transformed.
+        - scale: Optional scaling factor for the weight tensor.
+        - zeros: Optional zero-point adjustment for the weight tensor.
+        - bias: Optional bias to be added to the weight tensor.
+
+        Returns:
+        A list containing the transformed weight tensor and optionally the scale, zeros, and bias.
+        """
+        weight = weight.contiguous()
+        if self.W_dtype == self.A_dtype:
+            if self.weight_transform is not None:
+                return self.weight_transform(weight.cpu()).cuda().contiguous()
+            return weight
+
+        from bitblas.quantization import general_compress
+        import torch
+        import numpy as np
+
+        source_format, bit = self.source_format, self.bit
+
+        # Process integer source format
+        if source_format == "int" and bit < 8:
+            assert not self.with_scaling, "scale should be False for int source format"
+            assert not self.with_zeros, "zeros should be False for int source format"
+            maxq = 2**(bit - 1)
+            # Clamp weight values to be within the quantizable range and adjust
+            weight = torch.clamp(weight, -maxq, maxq).int() + maxq
+        elif source_format in ["fp_e5m2", "fp_e4m3"]:
+            weight = weight.view(torch.int8)
+            weight = weight.int()
+        else:
+            # For non-integer formats, simply convert weights to integers
+            weight = weight.int()
+
+        np_storage_dtype = getattr(np, self.storage_dtype)
+
+        weight = general_compress(
+            weight.cpu().numpy(), source_bits=bit, storage_dtype=np_storage_dtype)
+
+        weight = torch.from_numpy(weight).cuda().contiguous()
+
+        # Apply an optional weight transformation if specified
+        if self.weight_transform is not None:
+            weight = self.weight_transform(weight.cpu()).cuda().contiguous()
+
+        # Prepare the return list with the transformed weight and optionally include scale, zeros, and bias
+        result = [weight]
+        if scale is not None:
+            result.append(scale)
+        if zeros is not None:
+            result.append(zeros)
+        if bias is not None:
+            result.append(bias)
+
+        return next(iter(result), result)
+
+    def transform_input(self, input_tensor):
+        if self.propagate_a is not TransformKind.NonTransform:
+            # check workspace size
+            if input_tensor.numel() > WORKSPACE_SIZE:
+                raise ValueError(
+                    f"Input size {input_tensor.numel()} is larger than the workspace size {WORKSPACE_SIZE}, please increase the workspace size."
+                )
+            self.ladder_permutate_a._forward_from_prebuild_lib(input_tensor, self.workspace)
+            return self.workspace
+        return input_tensor
+
+    def forward(self, A, W, scale=None, zeros=None, bias=None, output=None) -> Any:
+        args = []
+        args.append(self.transform_input(A))
+        args.append(W)
+
+        if self.lut is not None:
+            args.append(self.lut)
+
+        if output is None:
+            output = torch.empty((self.k_split, ) + 
+                A.shape[:-1] + (self.N,), dtype=self.torch_output_dtype, device=A.device)
+        if scale is not None:
+            args.append(scale)
+        if zeros is not None:
+            args.append(zeros)
+        if bias is not None:
+            args.append(bias)
+        args.append(output)
+
+        if self.dynamic_range is not None:
+            m = reduce(operator.mul, A.shape[:-1], 1)
+            args.append(m)
+        
+        stream = torch.cuda.current_stream()
+
+        if self.lib is None:
+            self._forward_from_torch_func(*args)
+        self._forward_from_prebuild_lib(*args, stream=stream.cuda_stream)
+        output = torch.sum(output, dim=0)
+        return output
+
+    def __call__(self, *args: Any, **kwds: Any) -> Any:
+        return self.forward(*args, **kwds)
+
+    @property
+    def k_split(self):
+        return self.config.k_split
+
+
+__all__ = ["MatmulConfigWithSplitK", "MatmulWithSplitK"]

--- a/python/bitblas/ops/general_matmul_splitk.py
+++ b/python/bitblas/ops/general_matmul_splitk.py
@@ -3,7 +3,7 @@
 from tvm.target import Target
 import operator
 from functools import reduce
-from typing import Any, Optional,  Union
+from typing import Any, Optional, Union
 from .operator import TransformKind
 from .impl.matmul_splitk_impl import select_implementation as consistent_implementation
 from .impl.matmul_dequantize_splitk_impl import select_implementation as weight_dequantize_implementation
@@ -17,9 +17,10 @@ logger = logging.getLogger(__name__)
 
 WORKSPACE_SIZE = 1024 * 1024 * 256
 
+
 @dataclass(frozen=True)
 class MatmulConfigWithSplitK(MatmulConfig):
-    k_split: int = 1 # split K dimension
+    k_split: int = 1  # split K dimension
 
 
 class MatmulWithSplitK(Matmul):
@@ -158,8 +159,10 @@ class MatmulWithSplitK(Matmul):
             args.append(self.lut)
 
         if output is None:
-            output = torch.empty((self.k_split, ) + 
-                A.shape[:-1] + (self.N,), dtype=self.torch_output_dtype, device=A.device)
+            output = torch.empty(
+                (self.k_split,) + A.shape[:-1] + (self.N,),
+                dtype=self.torch_output_dtype,
+                device=A.device)
         if scale is not None:
             args.append(scale)
         if zeros is not None:
@@ -171,7 +174,7 @@ class MatmulWithSplitK(Matmul):
         if self.dynamic_range is not None:
             m = reduce(operator.mul, A.shape[:-1], 1)
             args.append(m)
-        
+
         stream = torch.cuda.current_stream()
 
         if self.lib is None:

--- a/python/bitblas/ops/impl/batch_matmul_dequantize_impl.py
+++ b/python/bitblas/ops/impl/batch_matmul_dequantize_impl.py
@@ -1,0 +1,389 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# pre-transformed tir expression of matmul
+import tvm
+from tvm import te, DataType
+from tvm.tir import IndexMap
+from bitblas.ops.operator import TransformKind
+from bitblas.gpu.matmul_analysis import get_propagate_map
+from bitblas.quantization import (
+    _tir_packed_int_to_int_convert,
+    _tir_packed_to_signed_convert,
+    _tir_packed_to_unsigned_convert,
+    _tir_u32_to_f4_to_f16,
+    _tir_u8_to_f8_e4m3_to_f16,
+    _tir_packed_to_unsigned_convert_with_zeros,
+)
+
+def matmul_nt_dequantize_b(
+    Batch,
+    M,
+    N,
+    K,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    bit=4,
+    storage_dtype="int8",
+    source_format="uint",
+    with_scaling=False,
+    with_zeros=False,
+    group_size=-1,
+    fast_decoding=False,
+    with_bias=False,
+    zeros_mode="original",
+):
+    assert bit in [1, 2, 4, 8], "Unsupported bit: {}".format(bit)
+    if not isinstance(M, int):
+        M = tvm.te.var("m")
+
+    storage_nbit = int("".join(c for c in storage_dtype if c.isdigit()))
+    storage_type = str("".join(c for c in storage_dtype if not c.isdigit()))
+    n_float_per_elem = storage_nbit // bit
+    if group_size == -1:
+        group_size = K
+    A = te.placeholder((Batch, M, K), name="A", dtype=in_dtype)
+    B = te.placeholder((Batch, N, K // storage_nbit * bit), name="B", dtype=storage_dtype)
+    LUT = te.placeholder((1 << bit,), name="LUT", dtype=in_dtype)
+    Scale = te.placeholder((Batch, N, K // group_size), name="Scale", dtype=in_dtype)
+    Bias = te.placeholder((N,), name="Bias", dtype=in_dtype)
+
+
+    def decode_func(b, n, k):
+        if source_format == "uint":
+            if bit == 8:
+                # 8 bit does not need to be compressed
+                w = B[b, n, k].astype(in_dtype)
+            else:
+                w = _tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
+                    bit, B[b, n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
+        elif source_format == "int":
+            if bit == 1:
+                # Dequantize int1 to -1 and 1. Without this step, the values would be 0 and 1, identical to uint1.
+                w = _tir_packed_int_to_int_convert(storage_type, storage_nbit)(
+                    bit, B[b, n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
+            elif bit == 8:
+                # 8 bit does not need to be compressed
+                w = B[b, n, k].astype(in_dtype)
+            else:
+                w = _tir_packed_to_signed_convert(storage_type, storage_nbit)(
+                    bit, B[b, n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
+        elif source_format == "fp":
+            w = _tir_u32_to_f4_to_f16(
+                bit, B[b, n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
+        elif source_format == "fp_e4m3":
+            w = _tir_u8_to_f8_e4m3_to_f16(bit, B[b, n, k], dtype=in_dtype)
+        elif source_format == "nf":
+            w = LUT[_tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
+                bit,
+                B[b, n, k // n_float_per_elem],
+                k % n_float_per_elem,
+                dtype="int32",  # assume the index data type is int32
+            )]
+        else:
+            raise ValueError("Unsupported source_format: {}".format(source_format))
+
+        if not with_scaling:
+            return w
+
+        if not with_zeros:
+            return w * Scale[b, n, k // group_size]
+
+        return w
+
+    B_decode = te.compute((Batch, N, K), decode_func, name="B_decode")
+    # Describe the matrix multiplication in TE
+    k = te.reduce_axis((0, K), name="k")
+    C = te.compute(
+        (Batch, M, N),
+        lambda b, i, j: te.sum(
+            A[b, i, k].astype(accum_dtype) * B_decode[b, j, k].astype(accum_dtype), axis=k),
+        name="C",
+    )
+    D = te.compute((Batch, M, N), lambda b, i, j: C[b, i, j].astype(out_dtype), name="D")
+    args = [A, B]
+    last_output = D
+    if source_format == "nf":
+        args.append(LUT)
+    if with_scaling:
+        args.append(Scale)
+    if with_bias:
+        E = te.compute((Batch, M, N), lambda b, i, j: D[b, i, j] + Bias[j], name="E")
+        last_output = E
+        args.append(Bias)
+    args.append(last_output)
+
+    func = te.create_prim_func(args).with_attr(
+        "dequantize_info",
+        {
+            "B_decode": {
+                "decode_block": "B_decode",
+                "fast_decoding": fast_decoding,
+                "source_format": {
+                    "bits": bit,
+                    "format": source_format,
+                },
+                "storage_dtype": storage_dtype,
+                "target_format": in_dtype,
+                "with_scaling": with_scaling,
+                "with_zeros": with_zeros,
+                "zeros_mode": zeros_mode,
+                "group_size": group_size,
+            }
+        },
+    )
+    return tvm.IRModule.from_expr(func)
+
+
+def matmul_nt_dequantize_b_propagate_b(
+    Batch,
+    M,
+    N,
+    K,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    bit=4,
+    storage_dtype="int8",
+    source_format="uint",
+    with_scaling=False,
+    with_zeros=False,
+    group_size=-1,
+    fast_decoding=False,
+    with_bias=False,
+    zeros_mode="original",
+    transform_kind: TransformKind = TransformKind.IntraWarpTransform,
+):
+    assert bit in [1, 2, 4, 8], "Unsupported bit: {}".format(bit)
+    if not isinstance(M, int):
+        M = tvm.te.var("m")
+
+    l = r = 16  # noqa: E741
+    if in_dtype in ["int8", "e4m3_float8", "e5m2_float8"]:
+        l, r = 16, 32  # noqa: E741
+
+    _, inverse_indexmap = get_propagate_map(trans=True, dtype=in_dtype, matrix_name="B")
+    target_dtype = DataType(in_dtype)
+    scaling_factor = 1
+    if bit > 0 and bit < target_dtype.bits:
+        scaling_factor = ((target_dtype.bits // bit) * DataType(storage_dtype).bits //
+                          target_dtype.bits)
+        initial_indices = inverse_indexmap.initial_indices
+        scaling_final_indices = inverse_indexmap.map_indices(initial_indices[:-1] +
+                                                             [initial_indices[-1] * scaling_factor])
+        scaling_final_indices = scaling_final_indices[:-1] + [
+            scaling_final_indices[-1] // scaling_factor
+        ]
+        inverse_indexmap = IndexMap(
+            initial_indices,
+            scaling_final_indices,
+            None,
+        )
+
+    storage_nbit = int("".join(c for c in storage_dtype if c.isdigit()))
+    storage_type = str("".join(c for c in storage_dtype if not c.isdigit()))
+    n_float_per_elem = storage_nbit // bit
+    if group_size == -1:
+        group_size = K
+    qr = r * bit // storage_nbit
+    A = te.placeholder((Batch, M, K), name="A", dtype=in_dtype)
+    B = te.placeholder((Batch, N // l, (K // scaling_factor) // qr, l, qr), name="B", dtype=storage_dtype)
+    LUT = te.placeholder((1 << bit,), name="LUT", dtype=in_dtype)
+    Scale = te.placeholder((Batch, N, K // group_size), name="Scale", dtype=in_dtype)
+    Zeros = te.placeholder((Batch, N, K // group_size), name="Zeros", dtype=in_dtype)
+    Bias = te.placeholder((Batch, N,), name="Bias", dtype=in_dtype)
+
+    def fcompute(b, i, j):
+        warp_i, warp_j = i % l, j % qr
+        spatial_args = i // l, j // qr
+        if transform_kind >= TransformKind.IntraWarpTransform:
+            warp_i, warp_j = inverse_indexmap.map_indices([warp_i, warp_j])
+        new_index = (b, *spatial_args, warp_i, warp_j)
+        return B[new_index]
+
+    B_reindex = te.compute(
+        (Batch, N, K // storage_nbit * bit),
+        fcompute,
+        name="B_reindex",
+    )
+
+    def decode_func(b, n, k):
+        if source_format == "uint":
+            if bit == 8:
+                # 8 bit does not need to be compressed
+                w = B_reindex[b, n, k].astype(in_dtype)
+            else:
+                w = _tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
+                    bit,
+                    B_reindex[b, n, k // n_float_per_elem],
+                    k % n_float_per_elem,
+                    dtype=in_dtype,
+                )
+        elif source_format == "int":
+            if bit == 1:
+                # Dequantize int1 to -1 and 1. Without this step, the values would be 0 and 1, identical to uint1.
+                w = _tir_packed_int_to_int_convert(storage_type, storage_nbit)(
+                    bit, B_reindex[b, n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
+            elif bit == 8:
+                # 8 bit does not need to be compressed
+                w = B_reindex[b, n, k].astype(in_dtype)
+            else:
+                w = _tir_packed_to_signed_convert(storage_type, storage_nbit)(
+                    bit,
+                    B_reindex[b, n, k // n_float_per_elem],
+                    k % n_float_per_elem,
+                    dtype=in_dtype,
+                )
+        elif source_format == "fp":
+            w = _tir_u32_to_f4_to_f16(
+                bit,
+                B_reindex[b, n, k // n_float_per_elem],
+                k % n_float_per_elem,
+                dtype=in_dtype,
+            )
+        elif source_format == "fp_e4m3":
+            w = _tir_u8_to_f8_e4m3_to_f16(bit, B_reindex[b, n, k], dtype=in_dtype)
+        elif source_format == "nf":
+            w = LUT[_tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
+                bit,
+                B_reindex[b, n, k // n_float_per_elem],
+                k % n_float_per_elem,
+                dtype="int32",  # assume the index data type is int32
+            )]
+        else:
+            raise ValueError("Unsupported source_format: {}".format(source_format))
+
+        if not with_scaling:
+            return w
+
+        if not with_zeros:
+            return w * Scale[b, n, k // group_size]
+
+        if zeros_mode == "original":
+            w = (w - Zeros[b, n, k // group_size]) * Scale[b, n, k // group_size]
+        elif zeros_mode == "rescale":
+            w = w * Scale[b, n, k // group_size] - Zeros[b, n, k // group_size]
+        else:
+            raise ValueError("Unsupported zeros_mode: {}".format(zeros_mode))
+
+        return w
+
+    B_decode = te.compute((Batch, N, K), decode_func, name="B_decode")
+
+    # Describe the matrix multiplication in TE
+    k = te.reduce_axis((0, K), name="k")
+    C = te.compute(
+        (Batch, M, N),
+        lambda b, i, j: te.sum(
+            A[b, i, k].astype(accum_dtype) * B_decode[b, j, k].astype(accum_dtype), axis=k),
+        name="C",
+    )
+    D = te.compute((Batch, M, N), lambda b, i, j: C[b, i, j].astype(out_dtype), name="D")
+    args = [A, B]
+    last_output = D
+    if source_format == "nf":
+        args.append(LUT)
+    if with_scaling:
+        args.append(Scale)
+    if with_zeros:
+        args.append(Zeros)
+    if with_bias:
+        E = te.compute((Batch, M, N), lambda b, i, j: D[b, i, j] + Bias[j], name="E")
+        last_output = E
+        args.append(Bias)
+    args.append(last_output)
+
+    func = te.create_prim_func(args).with_attr(
+        "dequantize_info",
+        {
+            "B_decode": {
+                "decode_block": "B_decode",
+                "fast_decoding": fast_decoding,
+                "source_format": {
+                    "bits": bit,
+                    "format": source_format,
+                },
+                "storage_dtype": storage_dtype,
+                "target_format": in_dtype,
+                "with_zeros": with_zeros,
+                "zeros_mode": zeros_mode,
+                "with_scaling": with_scaling,
+                "group_size": group_size,
+            }
+        },
+    )
+    func = func.with_attr("weight_transform_kind", transform_kind.value)
+    return tvm.IRModule.from_expr(func)
+
+
+def select_implementation(
+    Batch=1,
+    M=None,
+    N=1024,
+    K=1024,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    bit=4,
+    storage_dtype="int8",
+    source_format="uint",
+    with_scaling=False,
+    with_zeros=False,
+    group_size=-1,
+    fast_decoding=False,
+    with_bias=False,
+    layout="nt",
+    zeros_mode="original",
+    propagate_a=False,
+    propagate_b=False,
+):
+    if layout == "nn":
+        raise ValueError(
+            "Currently only support propagate_a=False and propagate_b=False for layout=nn in Dequantize Implementation"
+        )
+    elif layout == "nt":
+        if propagate_a and propagate_b:
+            raise ValueError("Currently only support propagate_a or propagate_b for layout=nt")
+        elif propagate_a:
+            raise ValueError("Currently only support propagate_a=False for layout=nt")
+        elif propagate_b:
+            return matmul_nt_dequantize_b_propagate_b(
+                Batch,
+                M,
+                N,
+                K,
+                in_dtype,
+                out_dtype,
+                accum_dtype,
+                bit,
+                storage_dtype,
+                source_format,
+                with_scaling,
+                with_zeros,
+                group_size,
+                fast_decoding,
+                with_bias,
+                zeros_mode,
+                transform_kind=propagate_b,
+            )
+        else:
+            return matmul_nt_dequantize_b(
+                Batch,
+                M,
+                N,
+                K,
+                in_dtype,
+                out_dtype,
+                accum_dtype,
+                bit,
+                storage_dtype,
+                source_format,
+                with_scaling,
+                with_zeros,
+                group_size,
+                fast_decoding,
+                with_bias,
+                zeros_mode,
+            )
+    else:
+        raise ValueError(f"Unsupported layout: {layout}")

--- a/python/bitblas/ops/impl/batch_matmul_impl.py
+++ b/python/bitblas/ops/impl/batch_matmul_impl.py
@@ -1,0 +1,93 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# pre-transformed tir expression of matmul
+import tvm
+from tvm import te
+from bitblas.gpu.matmul_analysis import get_propagate_map
+from bitblas.ops.operator import TransformKind
+
+
+def matmul_nt(
+    Batch,
+    M,
+    N,
+    K,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    with_bias=False,
+):
+    if not isinstance(M, int):
+        M = tvm.te.var("m")
+    A = te.placeholder((Batch, M, K), name="A", dtype=in_dtype)
+    B = te.placeholder((Batch, N, K), name="B", dtype=in_dtype)
+    Bias = te.placeholder((N,), name="Bias", dtype=in_dtype)
+
+    # Describe the matrix multiplication in TE
+    k = te.reduce_axis((0, K), name="k")
+    C = te.compute(
+        (Batch, M, N),
+        lambda b, i, j: te.sum(A[b, i, k].astype(accum_dtype) * B[b, j, k].astype(accum_dtype), axis=k),
+        name="C",
+    )
+    last_output = C
+    if accum_dtype != out_dtype:
+        D = te.compute((Batch, M, N), lambda b, i, j: C[b, i, j].astype(out_dtype), name="D")
+        last_output = D
+
+    if with_bias:
+        E = te.compute((Batch, M, N), lambda b, i, j: last_output[b, i, j] + Bias[j], name="E")
+        last_output = E
+
+    args = [A, B, Bias, last_output] if with_bias else [A, B, last_output]
+
+    func = te.create_prim_func(args)
+
+    return tvm.IRModule.from_expr(func)
+
+
+def matmul(
+    Batch,
+    M,
+    N,
+    K,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    with_bias=False,
+    layout="nt",
+):
+    if layout == "nn":
+        raise ValueError("Currently only support layout=nt")
+    return matmul_nt(Batch, M, N, K, in_dtype, out_dtype, accum_dtype, with_bias)
+
+
+def select_implementation(
+    Batch=1,
+    M=None,
+    N=16384,
+    K=16384,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    with_bias=False,
+    layout="nt",
+    propagate_a: TransformKind = TransformKind.NonTransform,
+    propagate_b: TransformKind = TransformKind.NonTransform,
+):
+    if layout == "nn":
+        if propagate_a or propagate_b:
+            raise ValueError(
+                "Currently only support propagate_a=False and propagate_b=False for layout=nn")
+        return matmul(M, N, K, in_dtype, out_dtype, accum_dtype, with_bias, layout)
+    elif layout == "nt":
+        if propagate_a and propagate_b:
+            raise ValueError("Currently only support propagate_a or propagate_b for layout=nt")
+        elif propagate_a:
+            raise ValueError("Currently only support propagate_a=False for layout=nt")
+        elif propagate_b:
+            raise ValueError("Currently only support propagate_b=False for layout=nt")
+        else:
+            return matmul(Batch, M, N, K, in_dtype, out_dtype, accum_dtype, with_bias, layout)
+    else:
+        raise ValueError(f"Unsupported layout: {layout}")

--- a/python/bitblas/ops/impl/batch_matmul_impl.py
+++ b/python/bitblas/ops/impl/batch_matmul_impl.py
@@ -3,7 +3,6 @@
 # pre-transformed tir expression of matmul
 import tvm
 from tvm import te
-from bitblas.gpu.matmul_analysis import get_propagate_map
 from bitblas.ops.operator import TransformKind
 
 
@@ -27,7 +26,8 @@ def matmul_nt(
     k = te.reduce_axis((0, K), name="k")
     C = te.compute(
         (Batch, M, N),
-        lambda b, i, j: te.sum(A[b, i, k].astype(accum_dtype) * B[b, j, k].astype(accum_dtype), axis=k),
+        lambda b, i, j: te.sum(
+            A[b, i, k].astype(accum_dtype) * B[b, j, k].astype(accum_dtype), axis=k),
         name="C",
     )
     last_output = C

--- a/python/bitblas/ops/impl/matmul_dequantize_splitk_impl.py
+++ b/python/bitblas/ops/impl/matmul_dequantize_splitk_impl.py
@@ -1,0 +1,191 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# pre-transformed tir expression of matmul
+import tvm
+from tvm import te, DataType
+from tvm.tir import IndexMap
+from bitblas.ops.operator import TransformKind
+from bitblas.gpu.matmul_analysis import get_propagate_map
+from bitblas.quantization import (
+    _tir_packed_int_to_int_convert,
+    _tir_packed_to_signed_convert,
+    _tir_packed_to_unsigned_convert,
+    _tir_u32_to_f4_to_f16,
+    _tir_u8_to_f8_e4m3_to_f16,
+    _tir_packed_to_unsigned_convert_with_zeros,
+)
+
+def matmul_nt_dequantize_b(
+    SplitK,
+    M,
+    N,
+    K,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    bit=4,
+    storage_dtype="int8",
+    source_format="uint",
+    with_scaling=False,
+    with_zeros=False,
+    group_size=-1,
+    fast_decoding=False,
+    with_bias=False,
+    zeros_mode="original",
+):
+    assert bit in [1, 2, 4, 8], "Unsupported bit: {}".format(bit)
+    if not isinstance(M, int):
+        M = tvm.te.var("m")
+
+    storage_nbit = int("".join(c for c in storage_dtype if c.isdigit()))
+    storage_type = str("".join(c for c in storage_dtype if not c.isdigit()))
+    n_float_per_elem = storage_nbit // bit
+    if group_size == -1:
+        group_size = K
+    A = te.placeholder((M, K), name="A", dtype=in_dtype)
+    B = te.placeholder((N, K // storage_nbit * bit), name="B", dtype=storage_dtype)
+    LUT = te.placeholder((1 << bit,), name="LUT", dtype=in_dtype)
+    Scale = te.placeholder((N, K // group_size), name="Scale", dtype=in_dtype)
+    Bias = te.placeholder((N,), name="Bias", dtype=in_dtype)
+
+
+    def decode_func(n, k):
+        if source_format == "uint":
+            if bit == 8:
+                # 8 bit does not need to be compressed
+                w = B[n, k].astype(in_dtype)
+            else:
+                w = _tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
+                    bit, B[n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
+        elif source_format == "int":
+            if bit == 1:
+                # Dequantize int1 to -1 and 1. Without this step, the values would be 0 and 1, identical to uint1.
+                w = _tir_packed_int_to_int_convert(storage_type, storage_nbit)(
+                    bit, B[n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
+            elif bit == 8:
+                # 8 bit does not need to be compressed
+                w = B[n, k].astype(in_dtype)
+            else:
+                w = _tir_packed_to_signed_convert(storage_type, storage_nbit)(
+                    bit, B[n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
+        elif source_format == "fp":
+            w = _tir_u32_to_f4_to_f16(
+                bit, B[n, k // n_float_per_elem], k % n_float_per_elem, dtype=in_dtype)
+        elif source_format == "fp_e4m3":
+            w = _tir_u8_to_f8_e4m3_to_f16(bit, B[n, k], dtype=in_dtype)
+        elif source_format == "nf":
+            w = LUT[_tir_packed_to_unsigned_convert(storage_type, storage_nbit)(
+                bit,
+                B[n, k // n_float_per_elem],
+                k % n_float_per_elem,
+                dtype="int32",  # assume the index data type is int32
+            )]
+        else:
+            raise ValueError("Unsupported source_format: {}".format(source_format))
+
+        if not with_scaling:
+            return w
+
+        if not with_zeros:
+            return w * Scale[n, k // group_size]
+
+        return w
+
+    B_decode = te.compute((N, K), decode_func, name="B_decode")
+    # Describe the matrix multiplication in TE
+    RK = K // SplitK
+    k = te.reduce_axis((0, RK), name="k")
+    C = te.compute(
+        (SplitK, M, N),
+        lambda sk, i, j: te.sum(
+            A[i, sk * RK + k].astype(accum_dtype) * B_decode[j, sk * RK + k].astype(accum_dtype), axis=k),
+        name="C",
+    )
+    D = te.compute((SplitK, M, N), lambda b, i, j: C[b, i, j].astype(out_dtype), name="D")
+    args = [A, B]
+    last_output = D
+    if source_format == "nf":
+        args.append(LUT)
+    if with_scaling:
+        args.append(Scale)
+    if with_bias:
+        E = te.compute((SplitK, M, N), lambda b, i, j: D[b, i, j] + Bias[j], name="E")
+        last_output = E
+        args.append(Bias)
+    args.append(last_output)
+
+    func = te.create_prim_func(args).with_attr(
+        "dequantize_info",
+        {
+            "B_decode": {
+                "decode_block": "B_decode",
+                "fast_decoding": fast_decoding,
+                "source_format": {
+                    "bits": bit,
+                    "format": source_format,
+                },
+                "storage_dtype": storage_dtype,
+                "target_format": in_dtype,
+                "with_scaling": with_scaling,
+                "with_zeros": with_zeros,
+                "zeros_mode": zeros_mode,
+                "group_size": group_size,
+            }
+        },
+    )
+    return tvm.IRModule.from_expr(func)
+
+
+def select_implementation(
+    SplitK=1,
+    M=None,
+    N=1024,
+    K=1024,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    bit=4,
+    storage_dtype="int8",
+    source_format="uint",
+    with_scaling=False,
+    with_zeros=False,
+    group_size=-1,
+    fast_decoding=False,
+    with_bias=False,
+    layout="nt",
+    zeros_mode="original",
+    propagate_a=False,
+    propagate_b=False,
+):
+    if layout == "nn":
+        raise ValueError(
+            "Currently only support propagate_a=False and propagate_b=False for layout=nn in Dequantize Implementation"
+        )
+    elif layout == "nt":
+        if propagate_a and propagate_b:
+            raise ValueError("Currently only support propagate_a or propagate_b for layout=nt")
+        elif propagate_a:
+            raise ValueError("Currently only support propagate_a=False for layout=nt")
+        elif propagate_b:
+            raise ValueError("Currently only support propagate_b=False for layout=nt")
+        else:
+            return matmul_nt_dequantize_b(
+                SplitK,
+                M,
+                N,
+                K,
+                in_dtype,
+                out_dtype,
+                accum_dtype,
+                bit,
+                storage_dtype,
+                source_format,
+                with_scaling,
+                with_zeros,
+                group_size,
+                fast_decoding,
+                with_bias,
+                zeros_mode,
+            )
+    else:
+        raise ValueError(f"Unsupported layout: {layout}")

--- a/python/bitblas/ops/impl/matmul_splitk_impl.py
+++ b/python/bitblas/ops/impl/matmul_splitk_impl.py
@@ -1,0 +1,94 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# pre-transformed tir expression of matmul
+import tvm
+from tvm import te
+from bitblas.gpu.matmul_analysis import get_propagate_map
+from bitblas.ops.operator import TransformKind
+
+
+def matmul_nt(
+    SplitK,
+    M,
+    N,
+    K,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    with_bias=False,
+):
+    if not isinstance(M, int):
+        M = tvm.te.var("m")
+    A = te.placeholder((M, K), name="A", dtype=in_dtype)
+    B = te.placeholder((N, K), name="B", dtype=in_dtype)
+    Bias = te.placeholder((N,), name="Bias", dtype=in_dtype)
+
+    # Describe the matrix multiplication in TE
+    RK = K // SplitK
+    k = te.reduce_axis((0, RK), name="k")
+    C = te.compute(
+        (SplitK, M, N),
+        lambda sk, i, j: te.sum(A[i, sk * RK + k].astype(accum_dtype) * B[j, sk * RK + k].astype(accum_dtype), axis=k),
+        name="C",
+    )
+    last_output = C
+    if accum_dtype != out_dtype:
+        D = te.compute((SplitK, M, N), lambda b, i, j: C[b, i, j].astype(out_dtype), name="D")
+        last_output = D
+
+    if with_bias:
+        E = te.compute((SplitK, M, N), lambda b, i, j: last_output[b, i, j] + Bias[j], name="E")
+        last_output = E
+
+    args = [A, B, Bias, last_output] if with_bias else [A, B, last_output]
+
+    func = te.create_prim_func(args)
+
+    return tvm.IRModule.from_expr(func)
+
+
+def matmul(
+    SplitK,
+    M,
+    N,
+    K,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    with_bias=False,
+    layout="nt",
+):
+    if layout == "nn":
+        raise ValueError("Currently only support layout=nt")
+    return matmul_nt(SplitK, M, N, K, in_dtype, out_dtype, accum_dtype, with_bias)
+
+
+def select_implementation(
+    SplitK=1,
+    M=None,
+    N=16384,
+    K=16384,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    with_bias=False,
+    layout="nt",
+    propagate_a: TransformKind = TransformKind.NonTransform,
+    propagate_b: TransformKind = TransformKind.NonTransform,
+):
+    if layout == "nn":
+        if propagate_a or propagate_b:
+            raise ValueError(
+                "Currently only support propagate_a=False and propagate_b=False for layout=nn")
+        return matmul(M, N, K, in_dtype, out_dtype, accum_dtype, with_bias, layout)
+    elif layout == "nt":
+        if propagate_a and propagate_b:
+            raise ValueError("Currently only support propagate_a or propagate_b for layout=nt")
+        elif propagate_a:
+            raise ValueError("Currently only support propagate_a=False for layout=nt")
+        elif propagate_b:
+            raise ValueError("Currently only support propagate_b=False for layout=nt")
+        else:
+            return matmul(SplitK, M, N, K, in_dtype, out_dtype, accum_dtype, with_bias, layout)
+    else:
+        raise ValueError(f"Unsupported layout: {layout}")

--- a/python/bitblas/ops/impl/matmul_splitk_impl.py
+++ b/python/bitblas/ops/impl/matmul_splitk_impl.py
@@ -3,7 +3,6 @@
 # pre-transformed tir expression of matmul
 import tvm
 from tvm import te
-from bitblas.gpu.matmul_analysis import get_propagate_map
 from bitblas.ops.operator import TransformKind
 
 
@@ -28,7 +27,8 @@ def matmul_nt(
     k = te.reduce_axis((0, RK), name="k")
     C = te.compute(
         (SplitK, M, N),
-        lambda sk, i, j: te.sum(A[i, sk * RK + k].astype(accum_dtype) * B[j, sk * RK + k].astype(accum_dtype), axis=k),
+        lambda sk, i, j: te.sum(
+            A[i, sk * RK + k].astype(accum_dtype) * B[j, sk * RK + k].astype(accum_dtype), axis=k),
         name="C",
     )
     last_output = C

--- a/python/bitblas/ops/operator.py
+++ b/python/bitblas/ops/operator.py
@@ -289,7 +289,7 @@ class Operator(ABC):
         ]
         ctypes_args.append(ctypes.c_void_p(stream))
         self.lib.call(*ctypes_args)
-    
+
     def call_lib(self, *args, stream=0):
         self.lib.call(*args, ctypes.c_void_p(stream))
 
@@ -340,6 +340,7 @@ class OPExecutorCPU:
     """
     A class to execute a sequence of operators on the CPU.
     """
+
     def __init__(self, operators: Optional[List[Operator]] = None):
         if operators is None:
             operators = []

--- a/python/bitblas/quantization/quantization.py
+++ b/python/bitblas/quantization/quantization.py
@@ -142,9 +142,9 @@ def _tir_u32_to_f4_to_f16(nbit: int, val: tir.PrimExpr, pos: tir.PrimExpr, dtype
 def _tir_u8_to_f8_e4m3_to_f16(nbit: int, val: tir.PrimExpr, dtype: str):
     assert nbit == 8
     assert dtype == "float16"
-    s_f16 = (val >> tir.const(7, "int16")) << tir.const(15, "int16")
-    offset = tir.Select(s_f16 == 0, tir.const(8192, "int16"), tir.const(-8192, "int16"))
-    e_f16 = ((val << tir.const(7, "int16")) + offset)
+    s_f16 = (val >> tir.const(7, "uint16")) << tir.const(15, "uint16")
+    prefix = tir.Select(s_f16 == 0, tir.const(0x2000, "uint16"), tir.const(0xc000, "uint16"))
+    e_f16 = (((val & tir.const(127, "uint16")) << tir.const(7, "uint16"))) | prefix
     return tir.reinterpret("float16", s_f16 | e_f16)
 
 

--- a/testing/python/operators/test_general_matmul_fp8.py
+++ b/testing/python/operators/test_general_matmul_fp8.py
@@ -166,7 +166,7 @@ def test_matmul_torch_forward_weight_dequantize(M, N, K, A_dtype, W_dtype, accum
     print("torch_ref_out", ref_out)
     print("bitblas_out", bitblas_out)
 
-    torch.testing.assert_allclose(ref_out, bitblas_out, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(ref_out, bitblas_out, rtol=1e-1, atol=1e-1)
 
 
 # fmt: on

--- a/testing/python/operators/test_general_matmul_splitk_ops.py
+++ b/testing/python/operators/test_general_matmul_splitk_ops.py
@@ -1,0 +1,121 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+import pytest
+import bitblas
+from bitblas.ops.general_matmul_splitk import MatmulWithSplitK, MatmulConfigWithSplitK
+import logging
+from bitblas import set_log_level
+
+
+def get_codegen_result(ops):
+    code = ops.get_source()
+    return code
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "M,N,K,A_dtype,W_dtype,accum_dtype,out_dtype,layout,with_bias,group_size,with_scaling,with_zeros,zeros_mode",
+    [
+        (1, 4096, 12800, "float16", "float16", "float16", "float16", "nt", False, -1, False, False,
+         None),
+        (16, 4096, 12800, "float16", "float16", "float16", "float16", "nt", False, -1, False, False,
+         None),
+    ],
+)
+def test_matmul_codegen_default(M, N, K, A_dtype, W_dtype, accum_dtype, out_dtype, layout,
+                                with_bias, group_size, with_scaling, with_zeros, zeros_mode):
+
+    matmul_config = MatmulConfigWithSplitK(
+        M=M,
+        N=N,
+        K=K,
+        A_dtype=A_dtype,
+        W_dtype=W_dtype,
+        accum_dtype=accum_dtype,
+        out_dtype=out_dtype,
+        layout=layout,
+        with_bias=with_bias,
+        group_size=group_size,
+        with_scaling=with_scaling,
+        with_zeros=with_zeros,
+        zeros_mode=zeros_mode,
+    )
+    matmul = MatmulWithSplitK(config=matmul_config, enable_tuning=False)
+    assert get_codegen_result(matmul)
+
+
+@pytest.mark.parametrize(
+    "M,N,K,A_dtype,W_dtype,accum_dtype,out_dtype,layout,with_bias,group_size,with_scaling,with_zeros,zeros_mode",
+    [
+        (1, 4096, 12800, "float16", "float16", "float16", "float16", "nt", False, -1, False, False,
+         None),
+        (16, 4096, 12800, "float16", "float16", "float16", "float16", "nt", False, -1, False, False,
+         None),
+    ],
+)
+def test_matmul_finetune(M, N, K, A_dtype, W_dtype, accum_dtype, out_dtype, layout, with_bias,
+                         group_size, with_scaling, with_zeros, zeros_mode):
+
+    matmul_config = MatmulConfigWithSplitK(
+        M=M,
+        N=N,
+        K=K,
+        A_dtype=A_dtype,
+        W_dtype=W_dtype,
+        accum_dtype=accum_dtype,
+        out_dtype=out_dtype,
+        layout=layout,
+        with_bias=with_bias,
+        group_size=group_size,
+        with_scaling=with_scaling,
+        with_zeros=with_zeros,
+        zeros_mode=zeros_mode,
+    )
+    matmul = MatmulWithSplitK(config=matmul_config, enable_tuning=False)
+    matmul.hardware_aware_finetune(topk=10)
+    assert get_codegen_result(matmul)
+
+@pytest.mark.parametrize(
+    "SPlitK,M,N,K,A_dtype,W_dtype,accum_dtype,out_dtype,layout,with_bias,group_size,with_scaling,with_zeros,zeros_mode",
+    [
+        (1, 1, 4096, 12800, "float16", "float16", "float16", "float16", "nt", False, -1, False, False,
+         None),
+        (4, 1, 4096, 12800, "float16", "float16", "float16", "float16", "nt", False, -1, False, False,
+         None),
+    ],
+)
+def test_matmul_torch_forward_consistent(SplitK, M, N, K, A_dtype, W_dtype, accum_dtype, out_dtype, layout, with_bias,
+                              group_size, with_scaling, with_zeros, zeros_mode):
+    import torch
+    torch.random.manual_seed(0)
+    matmul_config = MatmulConfigWithSplitK(
+        k_split=SplitK,
+        M=M,
+        N=N,
+        K=K,
+        A_dtype=A_dtype,
+        W_dtype=W_dtype,
+        accum_dtype=accum_dtype,
+        out_dtype=out_dtype,
+        layout=layout,
+        with_bias=with_bias,
+        group_size=group_size,
+        with_scaling=with_scaling,
+        with_zeros=with_zeros,
+        zeros_mode=zeros_mode,
+    )
+    matmul = MatmulWithSplitK(config=matmul_config, enable_tuning=False)
+
+    input_shape = (M, K)
+    weight_shape = (N, K) if layout == "nt" else (K, N)
+    inputs = []
+    inputs.append(torch.rand(input_shape, dtype=torch.float16).cuda() - 0.5)
+    inputs.append(torch.rand(weight_shape, dtype=torch.float16).cuda() - 0.5)
+    
+    output_bitblas = matmul.forward(*inputs)
+    output_torch = torch.matmul(inputs[0], inputs[1].t() if layout == "nt" else inputs[1])    
+    torch.testing.assert_close(output_bitblas, output_torch, rtol=1e-2, atol=1e-1)
+
+# fmt: on
+if __name__ == "__main__":
+    bitblas.testing.main()


### PR DESCRIPTION
This pull request introduces a number of changes across the `python/bitblas` package in order to improve the functionality of the BitBlas library. The changes include updates to the `Rasterization` and `TensorCoreExtraConfig` classes, modifications to the `fast_decode_impl` method, and the addition of the `MatmulWithSplitK` class.

Updates to `Rasterization` and `TensorCoreExtraConfig` classes:

* [`python/bitblas/base/roller/__init__.py`](diffhunk://#diff-978183b8170138304d9129386764cdab461eb69016439b00a227e433f5abb860R4): Imported new `Rasterization` classes.
* [`python/bitblas/base/roller/hint.py`](diffhunk://#diff-2484769c3525207d4e2b7031c12b42e99b8f16eab8f442e12c87d67930bbb1f2R214-R219): Added a new method `tensorcore_legalization` to the `TensorCoreExtraConfig` class.

Modifications to `fast_decode_impl` method:

* [`python/bitblas/gpu/intrin/lop3.py`](diffhunk://#diff-35154465a7819e5c425cf4ae4ee62bf48f98d44ee018e779c7621291858077e6L1486-R1490): Reformatted the arguments in the `get_fast_decode_intrin` calls within the `fast_decode_impl` method for better readability. [[1]](diffhunk://#diff-35154465a7819e5c425cf4ae4ee62bf48f98d44ee018e779c7621291858077e6L1486-R1490) [[2]](diffhunk://#diff-35154465a7819e5c425cf4ae4ee62bf48f98d44ee018e779c7621291858077e6L1500-L1503)

Addition of `MatmulWithSplitK` class:

* [`python/bitblas/ops/general_matmul_splitk.py`](diffhunk://#diff-01841c7dec39a94b5869f974a00ae4672b24fa9d28311ad290392bdbb806686eR1-R194): Added a new file implementing the `MatmulWithSplitK` class, which extends the functionality of the `Matmul` class with the ability to split the K dimension.

Other important changes:

* [`3rdparty/tvm`](diffhunk://#diff-fa909c93fe94e9aa04c9e7f19e5754a2bb274678ad5c6275ee4bf54c6f9b1066L1-R1): Updated the subproject commit.
* [`python/bitblas/base/roller/policy/tensorcore.py`](diffhunk://#diff-461c0419a8f9d319f773065f100185d585da2408b16b61ddf9795e6eaed96291R310): Added a call to `tensorcore_legalization` in the `_score` method.
* [`python/bitblas/module/__init__.py`](diffhunk://#diff-fb15c1a46ced4ddf735f2206985dae9fba1fa5a741b1006356790fc48c1ba94cL70-R70): Changed the default value of `fast_decoding` from `True` to `None` in the `__init__` method.
* [`python/bitblas/ops/general_matmul.py`](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L45-L72): Removed the `OPExecutorCPU` class and added a condition to check if fast decoding is supported in the `__initialize_fast_decoding` method. [[1]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715L45-L72) [[2]](diffhunk://#diff-81e35682ed966e32fe5e110305c7130cc822456a53399b12b93c4a1950b4d715R122-R133)