### PR TITLE
[FIX] Must validate ENV settings or wrong gpu selected  by  nvidia-smi  

### DIFF
--- a/python/bitblas/utils/target_detector.py
+++ b/python/bitblas/utils/target_detector.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-
+import os
 import subprocess
 from typing import List
 from thefuzz import process
@@ -33,9 +33,14 @@ def get_gpu_model_from_nvidia_smi(gpu_id: int = 0):
         logger.info("nvidia-smi failed with error: %s", e)
         return None
 
-    # Return the name of the first GPU if multiple are present
-    return output.split("\n")[0]
+    result = output.split("\n")
 
+    # for multiple cpus, CUDA_DEVICE_ORDER=PCI_BUS_ID must be set to match nvidia-smi or else gpu_id is
+    # most likely incorrect and the wrong gpu
+    if len(result) > 0 and os.environ.get("CUDA_DEVICE_ORDER") != 'PCI_BUS_ID':
+        raise EnvironmentError("Multi-gpu environment must set `CUDA_DEVICE_ORDER=PCI_BUS_ID`.")
+
+    return result[0]
 
 def find_best_match(tags, query):
     """

--- a/python/bitblas/utils/target_detector.py
+++ b/python/bitblas/utils/target_detector.py
@@ -37,7 +37,7 @@ def get_gpu_model_from_nvidia_smi(gpu_id: int = 0):
 
     # for multiple cpus, CUDA_DEVICE_ORDER=PCI_BUS_ID must be set to match nvidia-smi or else gpu_id is
     # most likely incorrect and the wrong gpu
-    if len(result) > 0 and os.environ.get("CUDA_DEVICE_ORDER") != 'PCI_BUS_ID':
+    if len(result) > 0 and os.environ.get("CUDA_DEVICE_ORDER") != "PCI_BUS_ID":
         raise EnvironmentError("Multi-gpu environment must set `CUDA_DEVICE_ORDER=PCI_BUS_ID`.")
 
     return result[0]

--- a/python/bitblas/utils/target_detector.py
+++ b/python/bitblas/utils/target_detector.py
@@ -35,7 +35,7 @@ def get_gpu_model_from_nvidia_smi(gpu_id: int = 0):
 
     gpus = output.split("\n")
 
-    # for multiple cpus, CUDA_DEVICE_ORDER=PCI_BUS_ID must be set to match nvidia-smi or else wrong
+    # for multiple gpus, CUDA_DEVICE_ORDER=PCI_BUS_ID must be set to match nvidia-smi or else wrong
     # gpu is returned for gpu_id
     if len(gpus) > 0 and os.environ.get("CUDA_DEVICE_ORDER") != "PCI_BUS_ID":
         raise EnvironmentError("Multi-gpu environment must set `CUDA_DEVICE_ORDER=PCI_BUS_ID`.")

--- a/python/bitblas/utils/target_detector.py
+++ b/python/bitblas/utils/target_detector.py
@@ -26,24 +26,24 @@ def get_gpu_model_from_nvidia_smi(gpu_id: int = 0):
     try:
         # Execute nvidia-smi command to get the GPU name
         output = subprocess.check_output(
-            ["nvidia-smi", f"--id={gpu_id}", "--query-gpu=gpu_name", "--format=csv,noheader"],
+            ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv,noheader"],
             encoding="utf-8",
         ).strip()
     except subprocess.CalledProcessError as e:
         logger.info("nvidia-smi failed with error: %s", e)
         return None
 
-    result = output.split("\n")
+    gpus = output.split("\n")
 
     # for multiple cpus, CUDA_DEVICE_ORDER=PCI_BUS_ID must be set to match nvidia-smi or else gpu_id is
     # most likely incorrect and the wrong gpu
-    if len(result) > 0 and os.environ.get("CUDA_DEVICE_ORDER") != "PCI_BUS_ID":
+    if len(gpus) > 0 and os.environ.get("CUDA_DEVICE_ORDER") != "PCI_BUS_ID":
         raise EnvironmentError("Multi-gpu environment must set `CUDA_DEVICE_ORDER=PCI_BUS_ID`.")
 
-    if gpu_id >= len(result) or gpu_id < 0:
-        raise ValueError(f"Passed gpu_id:{gpu_id} but there are {len(result)} detected Nvidia gpus.")
+    if gpu_id >= len(gpus) or gpu_id < 0:
+        raise ValueError(f"Passed gpu_id:{gpu_id} but there are {len(gpus)} detected Nvidia gpus.")
 
-    return result[0]
+    return gpus[gpu_id]
 
 def find_best_match(tags, query):
     """

--- a/python/bitblas/utils/target_detector.py
+++ b/python/bitblas/utils/target_detector.py
@@ -40,6 +40,9 @@ def get_gpu_model_from_nvidia_smi(gpu_id: int = 0):
     if len(result) > 0 and os.environ.get("CUDA_DEVICE_ORDER") != "PCI_BUS_ID":
         raise EnvironmentError("Multi-gpu environment must set `CUDA_DEVICE_ORDER=PCI_BUS_ID`.")
 
+    if gpu_id >= len(result) or gpu_id < 0:
+        raise ValueError(f"Passed gpu_id:{gpu_id} but there are {len(result)} detected Nvidia gpus.")
+
     return result[0]
 
 def find_best_match(tags, query):

--- a/python/bitblas/utils/target_detector.py
+++ b/python/bitblas/utils/target_detector.py
@@ -35,8 +35,8 @@ def get_gpu_model_from_nvidia_smi(gpu_id: int = 0):
 
     gpus = output.split("\n")
 
-    # for multiple cpus, CUDA_DEVICE_ORDER=PCI_BUS_ID must be set to match nvidia-smi or else gpu_id is
-    # most likely incorrect and the wrong gpu
+    # for multiple cpus, CUDA_DEVICE_ORDER=PCI_BUS_ID must be set to match nvidia-smi or else wrong
+    # gpu is returned for gpu_id
     if len(gpus) > 0 and os.environ.get("CUDA_DEVICE_ORDER") != "PCI_BUS_ID":
         raise EnvironmentError("Multi-gpu environment must set `CUDA_DEVICE_ORDER=PCI_BUS_ID`.")
 


### PR DESCRIPTION
nvidia-smi uses PCI_BUS_ID order but python program may be launched using default which is not PCI_BUS_ID order for gpu. If the env values do not match, wrong gpu is returned for `gpu_id`. Validate the env and raise error if issue exists. 

TESTS
* [x] gpu_id in range
* [x] gpu_id out of range
* [x] gpu_id with multi-gpu + no PCI_BUS_ID order
* [x] gpu_id with multi-gpu + PCI_BUS_ID order set