### PR TITLE
[CI] Edit the notify setting in our CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,12 @@ jobs:
         source bitblas_ci/bin/activate
         cd testing/python
         python -m pytest
+
+  # Control notifications
+  notify:
+    runs-on: self-hosted
+    needs: [format-check, build-test]
+    if: failure()
+    steps:
+    - name: Notification
+      run: echo "Jobs failed, but no email will be sent."

--- a/bitblas/ops/impl/__init__.py
+++ b/bitblas/ops/impl/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-from .lop3_permutate_impl import tir_interleave_weight # noqa: F401
+from .lop3_permutate_impl import tir_interleave_weight  # noqa: F401

--- a/bitblas/ops/impl/__init__.py
+++ b/bitblas/ops/impl/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-from .lop3_permutate_impl import tir_interleave_weight
+from .lop3_permutate_impl import tir_interleave_weight # noqa: F401

--- a/bitblas/ops/impl/base.py
+++ b/bitblas/ops/impl/base.py
@@ -2,15 +2,19 @@
 # Licensed under the MIT License.
 from abc import ABC, abstractmethod
 
+
 # TODO: Refactor all the tir script implementations to use this base class
 # Abstract base class for TIR script emitters
 class TIRScriptEmitter(ABC):
+
     @abstractmethod
     def emit(self):
         raise NotImplementedError
 
+
 # Abstract base class for TIR script selectors
 class TIRScriptSelector(ABC):
+
     @abstractmethod
     def select(self):
         raise NotImplementedError

--- a/bitblas/ops/impl/base.py
+++ b/bitblas/ops/impl/base.py
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+from abc import ABC, abstractmethod
+
+# TODO: Refactor all the tir script implementations to use this base class
+# Abstract base class for TIR script emitters
+class TIRScriptEmitter(ABC):
+    @abstractmethod
+    def emit(self):
+        raise NotImplementedError
+
+# Abstract base class for TIR script selectors
+class TIRScriptSelector(ABC):
+    @abstractmethod
+    def select(self):
+        raise NotImplementedError


### PR DESCRIPTION
This pull request introduces a number of changes primarily aimed at refactoring the `bitblas/ops/impl/batch_matmul_impl.py` file for better code organization and maintainability. The changes also include modifications to the Continuous Integration (CI) workflow and some minor adjustments in other files.

Refactoring of `bitblas/ops/impl/batch_matmul_impl.py`:

* The functions `matmul_nt` and `matmul` have been replaced with two new classes: `BatchMatMulEmitter` and `BatchMatMulSelector`. These classes encapsulate the same functionality but provide a more structured and maintainable approach.
* The `BatchMatMulEmitter` class is responsible for emitting the TIR script for batch matrix multiplication. It includes methods for validating dimensions, applying bias, and converting data types.
* The `BatchMatMulSelector` class is responsible for selecting the appropriate TIR script emitter based on the provided layout and propagation parameters.
* The `select_implementation` function has been updated to use the new `BatchMatMulSelector` class.

Changes in other files:

* A new `notify` job has been added to the CI workflow in `.github/workflows/ci.yml`. This job runs when previous jobs fail and prints a message indicating that the jobs have failed but no email will be sent.
* In `bitblas/ops/impl/__init__.py`, a `noqa: F401` comment has been added to the import statement for `tir_interleave_weight`. This prevents linters from flagging the imported but unused `tir_interleave_weight` as an error.
* The file `bitblas/ops/impl/base.py` has been created to provide two abstract base classes `TIRScriptEmitter` and `TIRScriptSelector` for TIR script emitters and selectors, respectively.