### PR TITLE
Fix database path default

### DIFF
--- a/bitblas/cache/operator.py
+++ b/bitblas/cache/operator.py
@@ -167,7 +167,9 @@ class OperatorCache:
 global_operator_cache = OperatorCache()
 
 
-def load_global_ops_cache(database_path=BITBLAS_DATABASE_PATH, target=None):
+def load_global_ops_cache(database_path=None, target=None):
+    if database_path is None:
+        database_path = get_database_path()
     if target is None:
         target = bitblas.auto_detect_nvidia_target()
     logger.info(f"Loading operators from database {database_path} for target {target}")


### PR DESCRIPTION
Before this change, the default for `database_path` would evaluate to the value that `BITBLAS_DATABASE_PATH` had upon the definition of the function, ignoring changes made using `set_database_path`.