### PR TITLE
Limiting parallel jobs for local build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ def build_tvm(llvm_config_path):
     # Run CMake and make
     try:
         subprocess.check_call(["cmake", ".."])
-        subprocess.check_call(["make", "-j"])
+        subprocess.check_call(["make", "-j$(nproc)"])
     except subprocess.CalledProcessError as error:
         raise RuntimeError("Failed to build TVM") from error
     finally:


### PR DESCRIPTION
When running 'pip install -e .', the number of parallel make jobs can cause memory exhaustion.
This patch limits the maximum parallel jobs to the maximum thread number.