### PR TITLE
[BUG] Set Device when kernel be applied into Multiple GPUs.

### DIFF
--- a/bitblas/gpu/matmul_mma_dequantize.py
+++ b/bitblas/gpu/matmul_mma_dequantize.py
@@ -992,18 +992,16 @@ class MatmulTensorizationMMAWithDequantizeInfo(GPUScheduleRule):
             sch.compute_at(block_shared_local_local, B_shared_vi, preserve_unit_loops=True)
 
             dequantize_block_local = block_shared_local
-            if ("zeros_mode" in weight_decode_info and
-                    weight_decode_info["zeros_mode"] == "quantized"):
-                if ("with_scaling" in weight_decode_info and weight_decode_info["with_scaling"]):
-                    block_local_scales = sch.cache_read(dequantize_block_local, b_idx + 1, "local")
-                    sch.compute_at(block_local_scales, B_shared_vi, preserve_unit_loops=True)
-                    # pop the scale block
-                    auto_inline_producers(sch, block_local_scales)
+            if ("with_scaling" in weight_decode_info and weight_decode_info["with_scaling"]):
+                block_local_scales = sch.cache_read(dequantize_block_local, b_idx + 1, "local")
+                sch.compute_at(block_local_scales, B_shared_vi, preserve_unit_loops=True)
+                # pop the scale block
+                auto_inline_producers(sch, block_local_scales)
 
-                if ("with_zeros" in weight_decode_info and weight_decode_info["with_zeros"]):
-                    block_local_zeros = sch.cache_read(dequantize_block_local, b_idx + 2, "local")
-                    sch.compute_at(block_local_zeros, B_shared_vi, preserve_unit_loops=True)
-                    auto_inline_producers(sch, block_local_zeros)
+            if ("with_zeros" in weight_decode_info and weight_decode_info["with_zeros"]):
+                block_local_zeros = sch.cache_read(dequantize_block_local, b_idx + 2, "local")
+                sch.compute_at(block_local_zeros, B_shared_vi, preserve_unit_loops=True)
+                auto_inline_producers(sch, block_local_zeros)
 
             for producer in weight_producers:
                 with suppress(Exception):

--- a/bitblas/module/__init__.py
+++ b/bitblas/module/__init__.py
@@ -312,12 +312,12 @@ class Linear(nn.Module):
             if bias is not None:
                 self.bias = bias
 
-    def repack_from_gptq(self, gptq_module):
+    def repack_from_gptq(self, gptq_module, device="cuda"):
         # qweight in gptq old quant linear stored with (out_features, in_features), should be transposed.
         qweight = gptq_module.qweight.T.contiguous().view(self.TORCH_STORAGE_DTYPE)
         intweight = unpack_qweight(qweight, self.bits).contiguous()
         if self.bitblas_matmul.weight_transform is not None:
-            qweight = self.bitblas_matmul.weight_transform(intweight.cpu()).cuda()
+            qweight = self.bitblas_matmul.weight_transform(intweight.cpu()).to(device)
         self.qweight = qweight
         # scales in gptq old quant linear stored with (in_features // group_size, out_features), should be transposed.
         scales = gptq_module.scales.T.contiguous().view(self.torch_dtype)

--- a/bitblas/ops/general_matmul/__init__.py
+++ b/bitblas/ops/general_matmul/__init__.py
@@ -667,7 +667,6 @@ class Matmul(Operator):
             args.append(bias)
         args.append(output)
 
-        # self._forward_from_torch_func(*args)
         if self.lib is None:
             self._forward_from_torch_func(*args)
         else:

--- a/bitblas/ops/general_matmul/__init__.py
+++ b/bitblas/ops/general_matmul/__init__.py
@@ -666,7 +666,7 @@ class Matmul(Operator):
         if bias is not None:
             args.append(bias)
         args.append(output)
-        
+
         # self._forward_from_torch_func(*args)
         if self.lib is None:
             self._forward_from_torch_func(*args)
@@ -678,7 +678,7 @@ class Matmul(Operator):
             stream = torch.cuda.current_stream(device=A.device)
             torch.cuda.set_device(A.device)
             self._forward_from_prebuild_lib(*args, stream=stream.cuda_stream)
-        
+
         return output
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:

--- a/bitblas/ops/general_matmul/__init__.py
+++ b/bitblas/ops/general_matmul/__init__.py
@@ -674,7 +674,7 @@ class Matmul(Operator):
             if self.dynamic_range is not None:
                 m = reduce(operator.mul, A.shape[:-1], 1)
                 args.append(m)
-            print(self.get_source())
+
             stream = torch.cuda.current_stream(device=A.device)
             torch.cuda.set_device(A.device)
             self._forward_from_prebuild_lib(*args, stream=stream.cuda_stream)

--- a/bitblas/ops/general_matmul/__init__.py
+++ b/bitblas/ops/general_matmul/__init__.py
@@ -666,7 +666,7 @@ class Matmul(Operator):
         if bias is not None:
             args.append(bias)
         args.append(output)
-        
+
         if self.lib is None:
             self._forward_from_torch_func(*args)
         else:

--- a/bitblas/ops/general_matmul/__init__.py
+++ b/bitblas/ops/general_matmul/__init__.py
@@ -666,7 +666,7 @@ class Matmul(Operator):
         if bias is not None:
             args.append(bias)
         args.append(output)
-
+        
         if self.lib is None:
             self._forward_from_torch_func(*args)
         else:
@@ -675,7 +675,6 @@ class Matmul(Operator):
                 args.append(m)
 
             stream = torch.cuda.current_stream(device=A.device)
-            torch.cuda.set_device(A.device)
             self._forward_from_prebuild_lib(*args, stream=stream.cuda_stream)
 
         return output


### PR DESCRIPTION
This pull request includes several changes to improve device compatibility and streamline the weight transformation process in the `bitblas` module. The most important changes involve modifying various functions to ensure they correctly handle the device context for GPU operations.

### Device Compatibility Improvements:

* [`bitblas/module/__init__.py`](diffhunk://#diff-31b9ec55b0bfed86accdccaf81747ebf9e26d1c36281acfede97662678812407L315-R320): Updated the `repack_from_gptq` method to accept a `device` parameter, allowing the weight transformation to be performed on the specified device.
* [`bitblas/ops/general_matmul/__init__.py`](diffhunk://#diff-74fe5dd2824cb03a0fb2b0a913a2fc5caeb9c08e5368c318cd32b3af7e6f52edL606-R606): Modified the `transform_weight` method to use the device of the input weight tensor instead of defaulting to CUDA. [[1]](diffhunk://#diff-74fe5dd2824cb03a0fb2b0a913a2fc5caeb9c08e5368c318cd32b3af7e6f52edL606-R606) [[2]](diffhunk://#diff-74fe5dd2824cb03a0fb2b0a913a2fc5caeb9c08e5368c318cd32b3af7e6f52edL627-R627)
* [`bitblas/ops/general_matmul/__init__.py`](diffhunk://#diff-74fe5dd2824cb03a0fb2b0a913a2fc5caeb9c08e5368c318cd32b3af7e6f52edR670-R679): Adjusted the `forward` method to set and use the correct CUDA stream based on the device of the input tensor `A`.

### Code Simplification:

* [`bitblas/gpu/matmul_mma_dequantize.py`](diffhunk://#diff-4a893772b7972bd9794f2e7f8a6702f11a047da82505d431b7ad9d14fd9d98fdL995-L996): Removed obsolete condition for `zeros_mode` and simplified the condition for `with_scaling`.