### PR TITLE
[AMD] Ladder End2End Update for Matrix Code and HIP Codegen

### DIFF
--- a/install_amd.sh
+++ b/install_amd.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# install requirements
+pip install -r requirements.txt
+
+# install llvm
+LLVM_VERSION="16.0.0"
+IS_AARCH64=false
+EXTRACT_PATH="3rdparty"
+
+UBUNTU_VERSION="16.04"
+if [[ "$LLVM_VERSION" > "16.0.0" ]]; then
+    UBUNTU_VERSION="20.04"
+elif [[ "$LLVM_VERSION" > "13.0.0" ]]; then
+    UBUNTU_VERSION="18.04"
+fi
+
+BASE_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}"
+if $IS_AARCH64; then
+    FILE_NAME="clang+llvm-${LLVM_VERSION}-aarch64-linux-gnu.tar.xz"
+else
+    FILE_NAME="clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-${UBUNTU_VERSION}.tar.xz"
+fi
+DOWNLOAD_URL="${BASE_URL}/${FILE_NAME}"
+
+mkdir -p "$EXTRACT_PATH"
+
+echo "Downloading $FILE_NAME from $DOWNLOAD_URL"
+curl -L -o "${EXTRACT_PATH}/${FILE_NAME}" "$DOWNLOAD_URL"
+
+if [ $? -ne 0 ]; then
+    echo "Download failed!"
+    exit 1
+fi
+
+echo "Extracting $FILE_NAME to $EXTRACT_PATH"
+tar -xJf "${EXTRACT_PATH}/${FILE_NAME}" -C "$EXTRACT_PATH"
+
+if [ $? -ne 0 ]; then
+    echo "Extraction failed!"
+    exit 1
+fi
+
+echo "Download and extraction completed successfully."
+
+LLVM_CONFIG_PATH="$(realpath ${EXTRACT_PATH}/$(basename ${FILE_NAME} .tar.xz)/bin/llvm-config)"
+echo "LLVM config path: $LLVM_CONFIG_PATH"
+
+# clone and build tvm
+git submodule update --init --recursive
+
+cd 3rdparty/tvm
+if [ -d build ]; then
+    rm -rf build
+fi
+mkdir build
+cp cmake/config.cmake build
+cd build
+echo "set(USE_LLVM $LLVM_CONFIG_PATH)" >> config.cmake && echo "set(USE_ROCM ON)" >> config.cmake
+
+cmake .. && make -j && cd ../../..
+
+echo "export TVM_HOME=$(pwd)/3rdparty/tvm" >> ~/.bashrc
+echo "export PYTHONPATH=\$TVM_HOME/python:$(pwd):\$PYTHONPATH" >> ~/.bashrc
+
+source ~/.bashrc

--- a/python/ladder/arch/MI250.py
+++ b/python/ladder/arch/MI250.py
@@ -15,4 +15,4 @@ class MI250:
         self.bandwidth = [1300, 14000]
         self.platform = "ROCm-CDNA2"
         self.compute_capability = "gfx90a"
-        self.target = tvm.target.Target("hip")
+        self.target = tvm.target.Target("hip --mcpu=gfx90a")

--- a/python/ladder/policy/default.py
+++ b/python/ladder/policy/default.py
@@ -349,7 +349,7 @@ class DefaultPolicy:
         td.rstep_map = rstep_map
         td.traffic, td.tile_map = self._compute_memory_traffic(output_tile)
         td.smem_cost, td.cached_tensors_map = self._compute_shared_memory_usage(td)
-        if td.smem_cost > self.arch.smem_cap * 1.2:
+        if td.smem_cost > self.arch.smem_cap:
             td.valid = False
             return td
         output_shape = self.output_nodes[0].get_space_dim()

--- a/python/ladder/policy/tc.py
+++ b/python/ladder/policy/tc.py
@@ -106,7 +106,7 @@ class TCPolicy(DefaultPolicy):
     def compute_node_stride_map(self, node: IRNode, td: TileDict):
         if not node.get_tag("tensorCoreConfig"):
             return super().compute_node_stride_map(node, td)
-        td.use_cutlass_mma[node] = self._use_cutlass_mma(node, td)
+        td.use_cutlass_mma[node] = self._use_cutlass_mma(node, td) if self.arch.platform == "CUDA" else False
         use_layout = self._can_implement_layout(node, td)
         AS_stride, BS_stride, C_stride = self._compute_tc_strides(node, td.get_tile(node), td.get_rstep(node))
         A_stride, B_stride, _ = self._compute_tc_strides(node, td.get_tile(node))

--- a/python/ladder/relay/transform/welder_tune_pass.py
+++ b/python/ladder/relay/transform/welder_tune_pass.py
@@ -6,7 +6,7 @@ from tvm import relay, ir
 from ladder.graph import IRNode, OutputNode, Node, PlaceHolderNode
 from ladder.te_utils import normalize_tensor_names
 from ladder.engine import Engine, MultiProcTunner
-from ..integration import add_source
+from ..integration import add_source, set_arch
 import logging
 
 logger = logging.getLogger(__name__)
@@ -29,6 +29,7 @@ class WelderTunePass(relay.ExprMutator):
     def __init__(self, arch, topk=20, save_perf_log=None):
         super().__init__()
         self.arch = arch
+        set_arch(arch)
         self.topk = topk
         # save_perf_log should be a directory
         self.save_perf_log_ = save_perf_log

--- a/python/ladder/schedule/tir_base.py
+++ b/python/ladder/schedule/tir_base.py
@@ -75,7 +75,6 @@ class TIRSchedulerBase(SchedulerBase):
                 "tir.add_lower_pass": self.passes,
                 "tir.disable_cse_tir": True,
                 "tir.use_async_copy": True,
-                "tir.merge_static_smem": False,
             }
         ):
             mod = tvm.build(self.sche.mod["main"], self.args, target=target)

--- a/python/ladder/schedule/tir_ladder.py
+++ b/python/ladder/schedule/tir_ladder.py
@@ -1448,8 +1448,18 @@ class TIRLadderMMAScheduler4D(TIRSchedulerBase):
             HIP_MFMA_LOAD_16x16_B_TRANS_SHARED_f16_INTRIN,
             HIP_MFMA_f16f16f32_INTRIN,
             HIP_MFMA_f16f16f32_TRANS_INTRIN,
+            HIP_MFMA_bf16bf16f32_TRANS_INTRIN,
+            HIP_MFMA_STORE_GLOBAL_16x16_f16_INTRIN,
             HIP_MFMA_STORE_SHARED_16x16_f32_INTRIN,
             HIP_MFMA_STORE_GLOBAL_16x16_f32_INTRIN,
+            HIP_MFMA_fill_16x16_i32_INTRIN,
+            HIP_MFMA_LOAD_16x16_A_SHARED_s8_INTRIN,
+            HIP_MFMA_LOAD_16x16_B_SHARED_s8_INTRIN,
+            HIP_MFMA_LOAD_16x16_B_TRANS_SHARED_s8_INTRIN,
+            HIP_MFMA_s8s8s32_INTRIN,
+            HIP_MFMA_s8s8s32_TRANS_INTRIN,
+            HIP_MFMA_STORE_SHARED_16x16_s32_INTRIN,
+            HIP_MFMA_STORE_GLOBAL_16x16_s32_INTRIN
         )
         # const val for testing
         warp_size = self.config.arch.warp_size
@@ -1471,11 +1481,9 @@ class TIRLadderMMAScheduler4D(TIRSchedulerBase):
         block_tile_M, block_tile_N = self.config.block[0], self.config.block[1]
         warp_tile_M, warp_tile_N = self.config.warp[0], self.config.warp[1]
         out_dtype = self.reduce_op.output(0).dtype
-        has_output_op = False
+        has_output_op = False # always set false for fp32 accum
         # todo: currently, the accum output is fp32, which cannot reuse the previous smem buffer (f16 dtype)
         # todo: should enhance tvm to resolve it.
-        # if self.reduce_op != None and self.reduce_op != self.output_op:
-        #     has_output_op = True
         def get_vec(in_dtype):
             if in_dtype == "float32" or in_dtype == "int32":
                 vec = 4
@@ -1508,7 +1516,7 @@ class TIRLadderMMAScheduler4D(TIRSchedulerBase):
         # chunk = 2
         # stage = 1
         # use_async = 0
-        # raster = 16
+        # raster = 10
         
         block_i, i, ii = sch.split(i, factors=[None, block_row_warps, warp_row_tiles])
         block_j, j, jj = sch.split(j, factors=[None, block_col_warps, warp_col_tiles])
@@ -1549,8 +1557,6 @@ class TIRLadderMMAScheduler4D(TIRSchedulerBase):
                 preserve_unit_loops=True,
             )
         
-        self.schedule_compute_inline()
-
         def schedule_shared_output(block, _vec):
             o_shared_fused = sch.fuse(*sch.get_loops(block)[-4:])
             _loop_extent = sch.get_sref(o_shared_fused).stmt.extent
@@ -1568,10 +1574,22 @@ class TIRLadderMMAScheduler4D(TIRSchedulerBase):
             schedule_shared_output(C_shared, vecC)
         
         write_sch(sch, "schedule_warp")
+        
+        self.schedule_compute_inline()
+
         write_sch(sch, "schedule_compute_inline")
 
-        a_prmt_func = thread_id_shared_access_64x4_to_16x16_layout_A
-        b_prmt_func = thread_id_shared_access_64x4_to_16x16_layout_B
+        def a_prmt_func(i, j):
+            _id = i * 16 + j
+            thread_id = _id // 4
+            local_id = _id % 4
+            return thread_id_shared_access_64x4_to_16x16_layout_A(thread_id, local_id)
+
+        def b_prmt_func(i, j):
+            _id = i * 16 + j
+            thread_id = _id // 4
+            local_id = _id % 4
+            return thread_id_shared_access_64x4_to_16x16_layout_B(thread_id, local_id)
 
         def A_permutation(*args):
             kernel_i, kernel_j = args[-2], args[-1]
@@ -1624,8 +1642,10 @@ class TIRLadderMMAScheduler4D(TIRSchedulerBase):
         b_index_map = shared_16x16_to_local_64x4_layout_A if transpose_B else shared_16x16_to_local_64x4_layout_B
         c_index_map = shared_16x16_to_local_64x4_layout_C
 
-        def index_map_A(i, k, wmma_m, wmma_k):
-            return (i, k, *a_index_map(wmma_m, wmma_k))
+        def index_map_A(*args):
+            kernel_i, kernel_j = args[-2], args[-1]
+            other_args = args[:-2]
+            return (*other_args, *a_index_map(kernel_i, kernel_j))
 
 
         def index_map_B(*args):
@@ -1635,8 +1655,10 @@ class TIRLadderMMAScheduler4D(TIRSchedulerBase):
             return result
 
 
-        def index_map_C(m, n, wmma_m, wmma_n):
-            return (m, n, *c_index_map(wmma_m, wmma_n),)
+        def index_map_C(*args):
+            kernel_i, kernel_j = args[-2], args[-1]
+            other_args = args[:-2]
+            return (*other_args, *c_index_map(kernel_i, kernel_j),)
 
 
         sch.transform_layout(AW, ("write", 0), index_map_A)
@@ -1644,13 +1666,22 @@ class TIRLadderMMAScheduler4D(TIRSchedulerBase):
         sch.transform_layout(C_warp, ("read", 0), index_map_C)
         
         # ------------------------ Tensorize and Pipelining -------------------------
-        init_intrin =  HIP_MFMA_fill_16x16_f32_INTRIN
-        load_a_intrin = HIP_MFMA_LOAD_16x16_A_SHARED_f16_INTRIN
-        load_b_intrin = HIP_MFMA_LOAD_16x16_B_SHARED_f16_INTRIN
-        load_b_intrin_trans = HIP_MFMA_LOAD_16x16_B_TRANS_SHARED_f16_INTRIN
-        compute_intrin = HIP_MFMA_f16f16f32_INTRIN
-        compute_trans_intrin = HIP_MFMA_f16f16f32_TRANS_INTRIN
-        store_intrin = HIP_MFMA_STORE_SHARED_16x16_f32_INTRIN if has_output_op else HIP_MFMA_STORE_GLOBAL_16x16_f32_INTRIN
+        init_intrin = HIP_MFMA_fill_16x16_i32_INTRIN if compute_dtype == "int32" else HIP_MFMA_fill_16x16_f32_INTRIN
+        load_a_intrin = HIP_MFMA_LOAD_16x16_A_SHARED_s8_INTRIN if compute_dtype == "int32" else HIP_MFMA_LOAD_16x16_A_SHARED_f16_INTRIN
+        load_b_intrin = HIP_MFMA_LOAD_16x16_B_SHARED_s8_INTRIN if compute_dtype == "int32" else HIP_MFMA_LOAD_16x16_B_SHARED_f16_INTRIN
+        load_b_intrin_trans = HIP_MFMA_LOAD_16x16_B_TRANS_SHARED_s8_INTRIN if compute_dtype == "int32" else HIP_MFMA_LOAD_16x16_B_TRANS_SHARED_f16_INTRIN
+        compute_intrin = HIP_MFMA_s8s8s32_INTRIN if compute_dtype == "int32" else HIP_MFMA_f16f16f32_INTRIN
+        compute_trans_intrin = HIP_MFMA_s8s8s32_TRANS_INTRIN if compute_dtype == "int32" else HIP_MFMA_f16f16f32_TRANS_INTRIN
+        if self.output_args[0].dtype == "float16":
+            store_intrin = HIP_MFMA_STORE_GLOBAL_16x16_f16_INTRIN
+        elif self.output_args[0].dtype == "float32":
+            store_intrin = HIP_MFMA_STORE_SHARED_16x16_f32_INTRIN if has_output_op else HIP_MFMA_STORE_GLOBAL_16x16_f32_INTRIN
+        elif self.output_args[0].dtype == "int32":
+            store_intrin = HIP_MFMA_STORE_SHARED_16x16_s32_INTRIN if has_output_op else HIP_MFMA_STORE_GLOBAL_16x16_s32_INTRIN
+        else:
+            raise NotImplementedError("dtype {} not supported".format(self.output_args[0].dtype))
+        if self.config.ladder_compute_type == "mxfp":
+            compute_intrin = HIP_MFMA_bf16bf16f32_TRANS_INTRIN
         init_block_b = sch.decompose_reduction(C, ko)
         write_sch(sch, "decompose_reduction")
         init_block_b_loops = sch.get_loops(init_block_b)
@@ -2275,6 +2306,352 @@ class TIRLadderMMAScheduler4D(TIRSchedulerBase):
 
         return sch.mod["main"]
     
+    def schedule_inconsistent_rocm_cdna(self, is_a_consistent=False, is_b_consistent=False):
+        from .ladder_intrin import (
+            thread_id_shared_access_64x1_to_16x4_layout_A,
+            thread_id_shared_access_64x4_to_16x16_layout_A,
+            thread_id_shared_access_64x1_to_4x16_layout_B,
+            thread_id_shared_access_64x4_to_16x16_layout_B,
+            thread_id_shared_access_64x4_to_16x16_layout_C,
+            shared_16x16_to_local_64x4_layout_A,
+            shared_16x16_to_local_64x4_layout_B,
+            shared_16x16_to_local_64x4_layout_C,
+            HIP_MFMA_fill_16x16_f32_INTRIN,
+            HIP_MFMA_LOAD_16x16_A_SHARED_f16_INTRIN,
+            HIP_MFMA_LOAD_16x16_B_SHARED_f16_INTRIN,
+            HIP_MFMA_LOAD_16x16_B_TRANS_SHARED_f16_INTRIN,
+            HIP_MFMA_f16f16f32_INTRIN,
+            HIP_MFMA_f16f16f32_TRANS_INTRIN,
+            HIP_MFMA_bf16bf16f32_TRANS_INTRIN,
+            HIP_MFMA_STORE_GLOBAL_16x16_f16_INTRIN,
+            HIP_MFMA_STORE_SHARED_16x16_f32_INTRIN,
+            HIP_MFMA_STORE_GLOBAL_16x16_f32_INTRIN,
+            HIP_MFMA_fill_16x16_i32_INTRIN,
+            HIP_MFMA_LOAD_16x16_A_SHARED_s8_INTRIN,
+            HIP_MFMA_LOAD_16x16_B_SHARED_s8_INTRIN,
+            HIP_MFMA_LOAD_16x16_B_TRANS_SHARED_s8_INTRIN,
+            HIP_MFMA_s8s8s32_INTRIN,
+            HIP_MFMA_s8s8s32_TRANS_INTRIN,
+            HIP_MFMA_STORE_SHARED_16x16_s32_INTRIN,
+            HIP_MFMA_STORE_GLOBAL_16x16_s32_INTRIN
+        )
+        # const val for testing
+        # assert is_a_consistent, "currently A should be consistent"
+        num_args = len(self.args)
+        is_lut = False
+        if num_args >= 4:
+            lut_arg = self.args[2] # assume the 3rd arg is the lut
+            lut_shape = np.prod(lut_arg.shape)
+            if lut_shape == 16:
+                is_lut = True
+        warp_size = self.config.arch.warp_size
+        compute_dtype = self.reduce_op.output(0).dtype
+        wmma_k = 32 if compute_dtype == "int32" else 16
+        has_output_op = (compute_dtype != "float32") # always set false for fp32 accum
+        shared_cache_c = (compute_dtype != "float32")
+        sch, config = self.sche, self.config
+        write_sch(sch, "original")
+        C = sch.get_block(self.reduce_op.name)
+        try:
+            i, j, kernel_i, kernel_j, k, kernel_k = sch.get_loops(C)
+        except ValueError:
+            b, i, j, kernel_i, kernel_j, k, kernel_k = sch.get_loops(C)
+            sch.bind(b, "blockIdx.z")
+        A_ax_m, A_ax_k, B_ax_k, B_ax_n, C_ax_m, C_ax_n = config.tc_extra_conf.tc_axis
+        propagate_inter_a= config.ladder_config.propagate_inter_a
+        propagate_inter_b = config.ladder_config.propagate_inter_b 
+        transpose_A = A_ax_k < A_ax_m
+        transpose_B = B_ax_k > B_ax_n
+        block_tile_M, block_tile_N = self.config.block[0], self.config.block[1]
+        warp_tile_M, warp_tile_N = self.config.warp[0], self.config.warp[1]
+        out_dtype = self.reduce_op.output(0).dtype
+        def get_vec(in_dtype):
+            if in_dtype == "float32" or in_dtype == "int32":
+                vec = 4
+            elif in_dtype == "float16":
+                vec = 8
+            elif in_dtype == "int8":
+                vec = 16
+            else:
+                raise NotImplementedError("dtype {} not supported".format(in_dtype))
+            return vec
+        vecA = get_vec(self.args[0].dtype)
+        vecB = get_vec(self.args[1].dtype)
+        vecC = get_vec(self.args[-1].dtype)
+        raster = self.config.raster_factor
+        # ------------------------ Block and Warp level job partition ------------------------
+        chunk_size = config.rstep[0] // wmma_k
+        warp_row_tiles = warp_tile_M
+        warp_col_tiles = warp_tile_N
+        block_row_warps = block_tile_M // warp_tile_M
+        block_col_warps = block_tile_N // warp_tile_N
+        chunk = chunk_size
+        stage = config.pipeline_stage
+        use_async = (propagate_inter_a and propagate_inter_b) and stage > 1
+
+        
+        block_i, i, ii = sch.split(i, factors=[None, block_row_warps, warp_row_tiles])
+        block_j, j, jj = sch.split(j, factors=[None, block_col_warps, warp_col_tiles])
+        ko, ki = sch.split(k, factors=[None, chunk])
+        sch.reorder(block_i, block_j, i, j, ko, ki, ii, jj, kernel_i, kernel_j, kernel_k)
+
+        write_sch(sch, "BlockTile")
+
+        sch.bind(block_i, "blockIdx.y")
+        sch.bind(block_j, "blockIdx.x")
+        sch.bind(i, "threadIdx.y")
+        sch.bind(j, "threadIdx.z")
+        self.block_size = (self.config.arch.warp_size, sch.get_sref(i).stmt.extent, sch.get_sref(j).stmt.extent)
+        self.grid_size = (sch.get_sref(block_j).stmt.extent, sch.get_sref(block_i).stmt.extent, 1)
+        write_sch(sch, "thread_bind")
+
+        # ------------------------ Shared memory layout for multiplicand A and B ------------------------
+
+        AS = sch.cache_read(C, 0, "shared")
+        BS = sch.cache_read(C, 1, "shared")
+        sch.compute_at(AS, ko, preserve_unit_loops=True)
+        sch.compute_at(BS, ko, preserve_unit_loops=True)
+        write_sch(sch, "cached_shared")
+        
+        # ------------------------ Schedule output fragment layout ------------------------
+        if shared_cache_c:
+            C_shared = sch.cache_write(C, 0, "shared")
+        C_warp = sch.cache_write(C, 0, "warp")
+        
+        sch.reverse_compute_at(C_warp, j, preserve_unit_loops=True)
+        if shared_cache_c:
+            sch.reverse_compute_at(
+                C_shared,
+                sch.get_loops(C_warp)[-3],
+                preserve_unit_loops=True,
+            )
+        
+        def schedule_shared_output(block, _vec):
+            o_shared_fused = sch.fuse(*sch.get_loops(block)[-4:])
+            _loop_extent = sch.get_sref(o_shared_fused).stmt.extent
+            if _vec * warp_size > _loop_extent:
+                _vec = _loop_extent // warp_size
+            oo, o_shared_tx, o_shared_vi = sch.split(
+                o_shared_fused, factors=[None, warp_size, _vec]
+            )     
+            sch.vectorize(o_shared_vi)
+            sch.bind(o_shared_tx, "threadIdx.x")
+            sch.unroll(oo)
+            sch.annotate(oo, "pragma_unroll_explicit", False)
+
+        if shared_cache_c:
+            schedule_shared_output(C_shared, vecC)
+        
+        write_sch(sch, "schedule_warp")
+        
+        def a_prmt_func(i, j):
+            _id = i * 16 + j
+            thread_id = _id // 4
+            local_id = _id % 4
+            return thread_id_shared_access_64x4_to_16x16_layout_A(thread_id, local_id)
+
+        def b_prmt_func(i, j):
+            _id = i * 16 + j
+            thread_id = _id // 4
+            local_id = _id % 4
+            return thread_id_shared_access_64x4_to_16x16_layout_B(thread_id, local_id)
+
+        def A_permutation(*args):
+            kernel_i, kernel_j = args[-2], args[-1]
+            other_args = args[:-2]
+            result = (*other_args, *a_prmt_func(kernel_i, kernel_j))
+            return result
+
+        def B_permutation(*args):
+            kernel_i, kernel_j = args[-2], args[-1]
+            other_args = args[:-2]
+            if transpose_B:
+                return (*other_args, *b_prmt_func(kernel_i, kernel_j))
+            else:
+                return (*other_args, *a_prmt_func(kernel_i, kernel_j))
+
+        if not propagate_inter_a:
+            sch.transform_layout(AS, ("read", 0),
+                                    A_permutation)
+        if not propagate_inter_b:
+            sch.transform_layout(BS, ("read", 0),
+                                    B_permutation)
+        
+        def cooperative_fetch(block, dims=4, vec=1, use_pragma_unroll=False, force_async_copy=False):
+            read_dtype = sch.get_sref(block).stmt.reads[-1].buffer.dtype
+            out_dtype = sch.get_sref(block).stmt.writes[-1].buffer.dtype
+            if read_dtype == "int8" and out_dtype == "float16":
+                vec = 4
+            
+            loops = sch.get_loops(block)[-dims:]
+            other_loop = loops[:-1]
+            shared_j = loops[-1]
+            shared_j, shared_vi = sch.split(shared_j, factors=[None, vec])
+            if sch.get_sref(shared_vi).stmt.extent in [1, 2, 4, 8, 16]:
+                sch.vectorize(shared_vi)
+            if force_async_copy and read_dtype == out_dtype:
+                sch.tensorize(shared_vi, ASYNC_COPY_F16_X8_INTRIN if read_dtype == "float16" else ASYNC_COPY_S8_X16_INTRIN)
+                sch.annotate(ki, "pragma_commit_wait", "")
+            shared_fused = sch.fuse(*other_loop, shared_j)
+            shared_inner, shared_ty, shared_tz, shared_tx = sch.split(
+                shared_fused, factors=[None, block_row_warps, block_col_warps, warp_size])
+            sch.bind(shared_tx, "threadIdx.x")
+            sch.bind(shared_ty, "threadIdx.y")
+            sch.bind(shared_tz, "threadIdx.z")
+            self.sche.unroll(shared_inner)
+            if use_pragma_unroll:
+                self.sche.annotate(shared_inner, "pragma_unroll_explicit", False)
+
+        if is_a_consistent:
+            cooperative_fetch(AS, dims=4, vec=vecA, use_pragma_unroll=True, force_async_copy=(propagate_inter_a and not propagate_inter_b))
+        if is_b_consistent:
+            cooperative_fetch(BS, dims=4, vec=vecB, use_pragma_unroll=True, force_async_copy=(propagate_inter_b and not propagate_inter_a))
+        A_decode_block = None
+        B_decode_block = None
+        other_blocks = []
+        for op in reversed(self.ops):
+            if op not in (self.reduce_op, *[arg.op for arg in self.output_args]):
+                if op.name == 'A_decode':
+                    A_decode_block = self.sche.get_block(op.name)
+                elif op.name == 'B_decode':
+                    B_decode_block = self.sche.get_block(op.name)
+                elif op.name == 'mediate0' and is_a_consistent and not is_b_consistent:
+                    B_decode_block = self.sche.get_block(op.name)
+                else:
+                    block = self.sche.get_block(op.name)
+                    other_blocks.append(block)
+            
+        if not is_a_consistent:
+            # cache_decompress
+            A_shared_jj = sch.get_loops(AS)[-1]
+            A_shared_jj, A_shared_vi, A_shared_vj = sch.split(A_shared_jj, factors=[None, 1, 8])
+            block_local_A_decompress = sch.cache_read(AS, 0, "local")
+            sch.compute_inline(A_decode_block)
+            block_local_A = sch.cache_read(block_local_A_decompress, 0, "local")
+            sch.compute_at(block_local_A_decompress, A_shared_vi)
+            sch.compute_at(block_local_A, A_shared_vi)
+            A_shared_fused = sch.fuse(*sch.get_loops(AS)[-6:-2])
+            A_shared_inner, A_shared_ty, A_shared_tz, A_shared_tx = sch.split(
+                A_shared_fused, factors=[None, block_row_warps, block_col_warps, warp_size])
+            sch.vectorize(sch.get_loops(AS)[-1])
+            sch.vectorize(sch.get_loops(block_local_A)[-1]) 
+            sch.bind(A_shared_tx, "threadIdx.x")
+            sch.bind(A_shared_ty, "threadIdx.y")
+            sch.bind(A_shared_tz, "threadIdx.z")
+        if not is_b_consistent:
+            # cache_decompress
+            B_shared_jj = sch.get_loops(BS)[-1]
+            B_shared_jj, B_shared_vi, B_shared_vj = sch.split(B_shared_jj, factors=[None, 1, 8])
+            block_local_B_decompress = sch.cache_read(BS, 0, "local")
+            sch.compute_inline(B_decode_block)
+            if is_lut:
+                block_local_B = sch.cache_read(block_local_B_decompress, 1, "local")
+            else:
+                block_local_B = sch.cache_read(block_local_B_decompress, 0, "local")
+            sch.compute_at(block_local_B_decompress, B_shared_vi)
+            sch.compute_at(block_local_B, B_shared_vi)
+            B_shared_fused = sch.fuse(*sch.get_loops(BS)[-6:-2])
+            B_shared_inner, B_shared_ty, B_shared_tz, B_shared_tx = sch.split(
+                B_shared_fused, factors=[None, block_row_warps, block_col_warps, warp_size])
+            sch.vectorize(sch.get_loops(BS)[-1])
+            sch.vectorize(sch.get_loops(block_local_B)[-1]) 
+            sch.bind(B_shared_tx, "threadIdx.x")
+            sch.bind(B_shared_ty, "threadIdx.y")
+            sch.bind(B_shared_tz, "threadIdx.z")
+            if is_lut:
+                block_shared_lut = sch.cache_read(block_local_B_decompress, 0, "shared")
+                sch.reverse_compute_at(block_shared_lut, j)
+                _, B_shared_tx = sch.split(
+                    sch.get_loops(block_shared_lut)[-1], factors=[None, warp_size])
+                sch.bind(B_shared_tx, "threadIdx.x")
+
+        for block in other_blocks:
+            self.sche.compute_inline(block)
+        if self.reduce_op != None and self.reduce_op != self.output_op:
+            block = self.sche.get_block(self.output_op.name)
+            self.sche.reverse_compute_inline(block)
+        write_sch(sch, "schedule_shared")
+        # ------------------------ Warp memory layout for multiplicand A and B ------------------------
+        AW = sch.cache_read(C, 0, "warp")
+        BW = sch.cache_read(C, 1, "warp")
+        sch.compute_at(AW, ki, preserve_unit_loops=True)
+        sch.compute_at(BW, ki, preserve_unit_loops=True)
+
+        a_index_map = shared_16x16_to_local_64x4_layout_A
+        b_index_map = shared_16x16_to_local_64x4_layout_A if transpose_B else shared_16x16_to_local_64x4_layout_B
+        c_index_map = shared_16x16_to_local_64x4_layout_C
+
+        def index_map_A(*args):
+            kernel_i, kernel_j = args[-2], args[-1]
+            other_args = args[:-2]
+            return (*other_args, *a_index_map(kernel_i, kernel_j))
+
+        def index_map_B(*args):
+            kernel_i, kernel_j = args[-2], args[-1]
+            other_args = args[:-2]
+            result = (*other_args, *b_index_map(kernel_i, kernel_j))
+            return result
+
+        def index_map_C(*args):
+            kernel_i, kernel_j = args[-2], args[-1]
+            other_args = args[:-2]
+            return (*other_args, *c_index_map(kernel_i, kernel_j),)
+
+
+        sch.transform_layout(AW, ("write", 0), index_map_A)
+        sch.transform_layout(BW, ("write", 0), index_map_A if not transpose_B else index_map_B)
+        sch.transform_layout(C_warp, ("read", 0), index_map_C)
+        
+        # ------------------------ Tensorize and Pipelining -------------------------
+        init_intrin = HIP_MFMA_fill_16x16_i32_INTRIN if compute_dtype == "int32" else HIP_MFMA_fill_16x16_f32_INTRIN
+        load_a_intrin = HIP_MFMA_LOAD_16x16_A_SHARED_s8_INTRIN if compute_dtype == "int32" else HIP_MFMA_LOAD_16x16_A_SHARED_f16_INTRIN
+        load_b_intrin = HIP_MFMA_LOAD_16x16_B_SHARED_s8_INTRIN if compute_dtype == "int32" else HIP_MFMA_LOAD_16x16_B_SHARED_f16_INTRIN
+        load_b_intrin_trans = HIP_MFMA_LOAD_16x16_B_TRANS_SHARED_s8_INTRIN if compute_dtype == "int32" else HIP_MFMA_LOAD_16x16_B_TRANS_SHARED_f16_INTRIN
+        compute_intrin = HIP_MFMA_s8s8s32_INTRIN if compute_dtype == "int32" else HIP_MFMA_f16f16f32_INTRIN
+        compute_trans_intrin = HIP_MFMA_s8s8s32_TRANS_INTRIN if compute_dtype == "int32" else HIP_MFMA_f16f16f32_TRANS_INTRIN
+        if self.output_args[0].dtype == "float16":
+            store_intrin = HIP_MFMA_STORE_GLOBAL_16x16_f16_INTRIN
+        elif self.output_args[0].dtype == "float32":
+            store_intrin = HIP_MFMA_STORE_SHARED_16x16_f32_INTRIN if has_output_op else HIP_MFMA_STORE_GLOBAL_16x16_f32_INTRIN
+        elif self.output_args[0].dtype == "int32":
+            store_intrin = HIP_MFMA_STORE_SHARED_16x16_s32_INTRIN if has_output_op else HIP_MFMA_STORE_GLOBAL_16x16_s32_INTRIN
+        else:
+            raise NotImplementedError("dtype {} not supported".format(self.output_args[0].dtype))
+
+        if self.config.ladder_compute_type == "mxfp":
+            compute_intrin = HIP_MFMA_bf16bf16f32_TRANS_INTRIN
+
+        init_block_b = sch.decompose_reduction(C, ko)
+        write_sch(sch, "decompose_reduction")
+        init_block_b_loops = sch.get_loops(init_block_b)
+        init_block_b_i, init_block_b_j = sch.get_loops(init_block_b)[-4:-2]
+        sch.annotate(init_block_b_i, "pragma_unroll_explicit", False)
+        sch.annotate(init_block_b_j, "pragma_unroll_explicit", False)
+        sch.tensorize(sch.get_loops(init_block_b)[-2], init_intrin)
+        sch.tensorize(
+            sch.get_loops(AW)[-2], load_a_intrin
+        )
+        sch.tensorize(
+            sch.get_loops(
+                BW)[-2], load_b_intrin if not transpose_B else load_b_intrin_trans
+        )
+        sch.tensorize(
+            kernel_i, compute_intrin if not transpose_B else compute_trans_intrin)
+        sch.tensorize(
+            sch.get_loops(C_warp)[-2],
+            store_intrin,
+        )
+        write_sch(sch, "tensorize_store")
+        if raster > 0:
+            sch.annotate(init_block_b_loops[-4], ann_key="thread_rasterization", ann_val=raster)
+        if stage > 1:
+            sch.annotate(ko, ann_key="software_pipeline_stage", ann_val=[0, 0, stage - 1])
+            sch.annotate(ko, ann_key="software_pipeline_order", ann_val=[0, 1, 2])
+
+        write_sch(sch, "cache_small_tensor")
+
+        return sch.mod["main"]
+
     def schedule(self) -> tir.Schedule:
         wmma_k = 32 if self.reduce_op.output(0).dtype == "int32" else 16
         if self.config.use_tc == "70":

--- a/python/ladder/tvm_build.py
+++ b/python/ladder/tvm_build.py
@@ -274,6 +274,10 @@ def tvm_build(
                 src,
                 1,
             )
-    src = tensor_replace_dp4a(src)
+    if target == "hip":
+        pass
+        # src = tensor_replace_vdot4(src)
+    else:
+        src = tensor_replace_dp4a(src)
     src = tensor_remove_make_int4(src)
     return src, exteral_shared_memroy_size, total_internal_shared_memory


### PR DESCRIPTION
This pull request includes various changes to the `ladder` project, primarily focusing on adding support for ROCm (AMD GPUs), enhancing the handling of different architectures, and improving the performance and functionality of the codebase.

### ROCm Support Enhancements:
* [`python/ladder/arch/MI250.py`](diffhunk://#diff-d94affec1634dbb078e4e9629b4b7808a45465d8b5725b037e1358e6f50ce028L18-R18): Updated the `target` initialization to include `--mcpu=gfx90a` for ROCm.
* [`python/ladder/header.py`](diffhunk://#diff-383a9f0205ed40f71c07ed6f489056562f4ca7bc239c16b4688aaa547061e293R263-R305): Added several ROCm-specific includes and definitions to support ROCm operations and data types. [[1]](diffhunk://#diff-383a9f0205ed40f71c07ed6f489056562f4ca7bc239c16b4688aaa547061e293R263-R305) [[2]](diffhunk://#diff-383a9f0205ed40f71c07ed6f489056562f4ca7bc239c16b4688aaa547061e293R355-R357)
* [`python/ladder/relay/integration.py`](diffhunk://#diff-922d70de546432037eaa444252fee123cd6e44b8c3299cee58d9d24e842b9aa2L15-R21): Added functions and logic to handle HIP compilation and integration for ROCm. [[1]](diffhunk://#diff-922d70de546432037eaa444252fee123cd6e44b8c3299cee58d9d24e842b9aa2L15-R21) [[2]](diffhunk://#diff-922d70de546432037eaa444252fee123cd6e44b8c3299cee58d9d24e842b9aa2R37) [[3]](diffhunk://#diff-922d70de546432037eaa444252fee123cd6e44b8c3299cee58d9d24e842b9aa2L42-R47) [[4]](diffhunk://#diff-922d70de546432037eaa444252fee123cd6e44b8c3299cee58d9d24e842b9aa2R84-R125)

### Architecture Handling Improvements:
* [`python/ladder/relay/integration.py`](diffhunk://#diff-922d70de546432037eaa444252fee123cd6e44b8c3299cee58d9d24e842b9aa2L15-R21): Introduced global architecture settings and modified functions to use these settings. [[1]](diffhunk://#diff-922d70de546432037eaa444252fee123cd6e44b8c3299cee58d9d24e842b9aa2L15-R21) [[2]](diffhunk://#diff-922d70de546432037eaa444252fee123cd6e44b8c3299cee58d9d24e842b9aa2R37) [[3]](diffhunk://#diff-922d70de546432037eaa444252fee123cd6e44b8c3299cee58d9d24e842b9aa2L42-R47)
* [`python/ladder/relay/transform/ladder_gemm_perfectmatmul.py`](diffhunk://#diff-b118db1f3339216210dc4d8ff370bbf7cad867533cfbb7ce77ba67aa0717fdaeR3-R7): Modified the `LadderPerfectGemmTransform` class to handle different architectures and added ROCm-specific logic. [[1]](diffhunk://#diff-b118db1f3339216210dc4d8ff370bbf7cad867533cfbb7ce77ba67aa0717fdaeR3-R7) [[2]](diffhunk://#diff-b118db1f3339216210dc4d8ff370bbf7cad867533cfbb7ce77ba67aa0717fdaeL62-R71) [[3]](diffhunk://#diff-b118db1f3339216210dc4d8ff370bbf7cad867533cfbb7ce77ba67aa0717fdaeR141) [[4]](diffhunk://#diff-b118db1f3339216210dc4d8ff370bbf7cad867533cfbb7ce77ba67aa0717fdaeR179-R244)

### Performance and Functionality Enhancements:
* [`python/ladder/policy/default.py`](diffhunk://#diff-9e8c1252008f4b9786a5244f1faac133abe0dc354139477318633a83099e872aL352-R352): Adjusted shared memory usage validation to be more strict.
* [`python/ladder/policy/tc.py`](diffhunk://#diff-ea2eca45b71260655b466f53fbd4367e09fa1d5fa5e3512c78b6f4ac7590f560L109-R109): Modified the `compute_node_stride_map` method to disable CUTLASS MMA for non-CUDA platforms.
* [`python/ladder/schedule/ladder_intrin.py`](diffhunk://#diff-5b9c0d29ee2d707f7323abd3e9cd7ad7cc267ebbc1117669ea9bb3569aa8f4c7L1343): Various changes to improve the handling of MFMA (Matrix-Fused Multiply-Add) operations, including support for different data types and architectures. [[1]](diffhunk://#diff-5b9c0d29ee2d707f7323abd3e9cd7ad7cc267ebbc1117669ea9bb3569aa8f4c7L1343) [[2]](diffhunk://#diff-5b9c0d29ee2d707f7323abd3e9cd7ad7cc267ebbc1117669ea9bb3569aa8f4c7L1418-R1417) [[3]](diffhunk://#diff-5b9c0d29ee2d707f7323abd3e9cd7ad7cc267ebbc1117669ea9bb3569aa8f4c7R1427) [[4]](diffhunk://#diff-5b9c0d29ee2d707f7323abd3e9cd7ad7cc267ebbc1117669ea9bb3569aa8f4c7R1446-R1454) [[5]](diffhunk://#diff-5b9c0d29ee2d707f7323abd3e9cd7ad7cc267ebbc1117669ea9bb3569aa8f4c7L1572-R1578) [[6]](diffhunk://#diff-5b9c0d29ee2d707f7323abd3e9cd7ad7cc267ebbc1117669ea9bb3569aa8f4c7L1585-R1596) [[7]](diffhunk://#diff-5b9c0d29ee2d707f7323abd3e9cd7ad7cc267ebbc1117669ea9bb3569aa8f4c7L1604-R1607) [[8]](diffhunk://#diff-5b9c0d29ee2d707f7323abd3e9cd7ad7cc267ebbc1117669ea9bb3569aa8f4c7L1614-R1617) [[9]](diffhunk://#diff-5b9c0d29ee2d707f7323abd3e9cd7ad7cc267ebbc1117669ea9bb3569aa8f4c7L1630-L1636)

### Miscellaneous Changes:
* [`3rdparty/tvm`](diffhunk://#diff-fa909c93fe94e9aa04c9e7f19e5754a2bb274678ad5c6275ee4bf54c6f9b1066L1-R1): Updated the submodule commit to a newer version.
* [`python/ladder/relay/transform/welder_tune_pass.py`](diffhunk://#diff-1d88b6ff33400a28a4d86df99ade1fc51750041ddadca2f125016dd077c4dd7aL9-R9): Added architecture setting in the `WelderTunePass` class. [[1]](diffhunk://#diff-1d88b6ff33400a28a4d86df99ade1fc51750041ddadca2f125016dd077c4dd7aL9-R9) [[2]](diffhunk://#diff-1d88b6ff33400a28a4d86df99ade1fc51750041ddadca2f125016dd077c4dd7aR32)

These changes collectively enhance the functionality, performance, and compatibility of the `ladder` project, especially in terms of supporting ROCm and improving architecture-specific handling.