### PR TITLE
[Dev][TL] Enhance TL Paser to support flexible tile lang kernel implementation

### DIFF
--- a/bitblas/ops/base_scheduler.py
+++ b/bitblas/ops/base_scheduler.py
@@ -27,7 +27,9 @@ class BaseScheduler(ABC):
     @staticmethod
     def Simplify(stmt: Union[PrimFunc, IRModule]):
         if isinstance(stmt, PrimFunc):
-            return Simplify()(IRModule.from_expr(stmt))["main"]
+            mod = Simplify()(IRModule.from_expr(stmt))
+            assert len(mod.functions) == 1, "Simplify should return a single function"
+            return list(mod.functions.values()).pop()
         elif isinstance(stmt, IRModule):
             return Simplify()(stmt)
         else:

--- a/testing/python/operators/test_general_matmul_tilelang_scheduler.py
+++ b/testing/python/operators/test_general_matmul_tilelang_scheduler.py
@@ -6,16 +6,17 @@ import bitblas.testing
 from tvm.ir import structural_equal
 from bitblas.ops.general_matmul.tilelang.dense.matmul_tensorcore import (
     MatmulScheduler,)
+from bitblas.ops.general_matmul.tilelang.dequantize import (MatmulDequantizeScheduler)
 
 
-def assert_scheduler_simplify(M,
-                              N,
-                              K,
-                              trans_A=False,
-                              trans_B=True,
-                              in_dtype="float16",
-                              out_dtype="float16",
-                              accum_dtype="float16"):
+def assert_dense_scheduler_simplify(M,
+                                    N,
+                                    K,
+                                    trans_A=False,
+                                    trans_B=True,
+                                    in_dtype="float16",
+                                    out_dtype="float16",
+                                    accum_dtype="float16"):
     matmul = MatmulScheduler(
         M=M,
         N=N,
@@ -33,8 +34,62 @@ def assert_scheduler_simplify(M,
     assert is_equal is False, "Simplify should not return the same schedule"
 
 
+def assert_dequantize_scheduler_simplify(
+    M,
+    N,
+    K,
+    trans_A=False,
+    trans_B=True,
+    in_dtype="float16",
+    out_dtype="float16",
+    accum_dtype="float16",
+    num_bits=4,
+    storage_dtype="int8",
+    source_format="uint",
+    with_scaling=False,
+    with_zeros=False,
+    group_size=-1,
+    fast_decoding=False,
+    zeros_mode="original",
+):
+    matmul = MatmulDequantizeScheduler(
+        M=M,
+        N=N,
+        K=K,
+        trans_A=trans_A,
+        trans_B=trans_B,
+        in_dtype=in_dtype,
+        out_dtype=out_dtype,
+        accum_dtype=accum_dtype,
+        num_bits=num_bits,
+        storage_dtype=storage_dtype,
+        source_format=source_format,
+        with_scaling=with_scaling,
+        with_zeros=with_zeros,
+        group_size=group_size,
+        fast_decoding=fast_decoding,
+        zeros_mode=zeros_mode,
+    ).deactivate_simplify().with_default_config()
+
+    simplified = MatmulDequantizeScheduler.Simplify(matmul)
+    print(simplified)
+    is_equal = structural_equal(matmul, simplified)
+    assert is_equal is False, "Simplify should not return the same schedule"
+
+
 def test_scheduler_simplify():
-    assert_scheduler_simplify(128, 128, 128)
+    assert_dense_scheduler_simplify(128, 128, 128)
+
+
+def test_dequantize_scheduler_simplify():
+    assert_dequantize_scheduler_simplify(128, 128, 128)
+    assert_dequantize_scheduler_simplify(128, 128, 128, with_scaling=True)
+    assert_dequantize_scheduler_simplify(
+        128, 128, 128, with_scaling=True, with_zeros=True, zeros_mode="original")
+    assert_dequantize_scheduler_simplify(
+        128, 128, 128, with_scaling=True, with_zeros=True, zeros_mode="rescale")
+    assert_dequantize_scheduler_simplify(
+        128, 128, 128, with_scaling=True, with_zeros=True, zeros_mode="quantized")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request includes several changes to the `bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.py` file, focusing on refactoring and enhancing the dequantization process. It also updates the `bitblas/ops/base_scheduler.py` file to add an assertion for function simplification and modifies test cases in `testing/python/operators/test_general_matmul_tilelang_scheduler.py` to include new dequantization scenarios.

### Enhancements to Dequantization Process:
* Refactored `apply_config` method to streamline the configuration process and removed redundant methods for different scaling and zero modes. (`bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.py`, [[1]](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L177-R178) [[2]](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L302-R322)
* Introduced `_normal_dequant` method for handling different dequantization scenarios based on scaling and zero modes. (`bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.py`, [bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.pyR367-R488](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022R367-R488))
* Added buffer shapes for LUT, Scale, Zeros, Qzeros, and Bias in the dequantization process. (`bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.py`, [bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.pyR222-R226](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022R222-R226))

### Code Quality Improvements:
* Ensured the `Simplify` method returns a single function and added an assertion to enforce this. (`bitblas/ops/base_scheduler.py`, [bitblas/ops/base_scheduler.pyL30-R32](diffhunk://#diff-1ce8a161a5b58d85057d647e262724e64934c352b3199a7d085c40c1d70c296dL30-R32))
* Corrected the `zeros_mode` default value to a tuple format. (`bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.py`, [bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.pyL52-R52](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L52-R52))
* Formatted multiline expressions for better readability. (`bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.py`, [[1]](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L135-R136) [[2]](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L273-R283) [[3]](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L283-R311)

### Test Cases:
* Added new test cases to validate the dequantization scheduler with various configurations, including scaling and different zero modes. (`testing/python/operators/test_general_matmul_tilelang_scheduler.py`, [testing/python/operators/test_general_matmul_tilelang_scheduler.pyR37-R92](diffhunk://#diff-9ec5249617821fa5b835ab94a80fa9b3e44a15ce612a49534cbe07770f5375aeR37-R92))

### Submodule Update:
* Updated the `tvm` submodule to a new commit. (`3rdparty/tvm`, [3rdparty/tvmL1-R1](diffhunk://#diff-fa909c93fe94e9aa04c9e7f19e5754a2bb274678ad5c6275ee4bf54c6f9b1066L1-R1))