### PR TITLE
[Dev][TL] Implement Tile Language Dequant Matmul and Test Case

### DIFF
--- a/bitblas/gpu/intrin/lop3.py
+++ b/bitblas/gpu/intrin/lop3.py
@@ -1685,6 +1685,12 @@ def get_lop3_intrin_group(
         raise ValueError("Unsupported target dtype: {}".format(target_dtype))
     source_symbol = "u" if source_format == "uint" else "s"
     func_name = "decode_i{}{}_to_{}".format(source_bit, source_symbol, d4f)
+    if with_scaling:
+        func_name += "_scale"
+    if with_zeros:
+        func_name += f"_zeros_{zeros_mode}"
+    if is_ladder_stage3:
+        func_name += "_offset"
 
     return {
         "func_name": func_name,

--- a/bitblas/ops/base_scheduler.py
+++ b/bitblas/ops/base_scheduler.py
@@ -64,3 +64,9 @@ class BaseScheduler(ABC):
         **kwargs,
     ):
         pass
+
+    @property
+    def common_header(self):
+        # TODO(lei): For HIP Backend it should be different
+        common_header = "#include <tl_templates/cuda/common.h>\n"
+        return common_header

--- a/bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.py
@@ -234,14 +234,17 @@ class MatmulDequantizeScheduler(BaseScheduler):
         if fast_decoding is True:
             lop3_intrin_info = get_lop3_intrin_group(
                 out_dtype=out_dtype,
-                storage_dtype=storage_dtype,
                 source_format=source_format,
                 source_bit=num_bits,
+                storage_dtype=storage_dtype,
+                with_scaling=self.with_scaling,
+                with_zeros=self.with_zeros,
             )
             import_source = lop3_intrin_info["c_source"]
             func_name = lop3_intrin_info["func_name"]
             assert import_source is not None, "lop3_intrin_info is not found"
             assert func_name is not None, "lop3_intrin_info is not found"
+            import_source = self.common_header + import_source
 
         @T.prim_func
         def general_dequant_matmul(
@@ -286,11 +289,20 @@ class MatmulDequantizeScheduler(BaseScheduler):
                             B_local[v] = B_shared[vi, vj]
 
                         if fast_decoding is True:
-                            T.call_extern(
+                            self._normal_fast_dequant(
+                                B_local,
+                                B_dequantize_local,
+                                Scale,
+                                Zeros,
+                                Qzeros,
                                 func_name,
-                                T.address_of(B_local[0]),
-                                T.address_of(B_dequantize_local[0]),
-                                dtype=in_dtype,
+                                by,
+                                tx,
+                                k,
+                                i,
+                                block_N,
+                                block_K,
+                                threads,
                             )
                         else:
                             self._normal_dequant(
@@ -364,7 +376,6 @@ class MatmulDequantizeScheduler(BaseScheduler):
 
         return dequant_func
 
-    # proxy method for macro expansion
     def _normal_dequant(
         self,
         compressed_weight_local: T.Buffer,
@@ -459,6 +470,81 @@ class MatmulDequantizeScheduler(BaseScheduler):
                     )) * scale_buffer[pid_n * stride_n + vi, (k * stride_k + vj) // group_size]
 
         return _normal_dequant_impl(
+            compressed_weight_local,
+            dequant_weight_local,
+            scale_buffer,
+            zeros_buffer,
+            qzeros_buffer,
+        )
+
+    def _normal_fast_dequant(
+        self,
+        compressed_weight_local: T.Buffer,
+        dequant_weight_local: T.Buffer,
+        scale_buffer: T.Buffer,
+        zeros_buffer: T.Buffer,
+        qzeros_buffer: T.Buffer,
+        func_name: str,
+        pid_n: T.Var,
+        tx: T.Var,
+        k: T.Var,
+        i: T.Var,
+        stride_n: int,
+        stride_k: int,
+        threads: int,
+    ):
+        num_elems_per_byte = self.num_elems_per_byte
+        with_scaling = self.with_scaling
+        with_zeros = self.with_zeros
+        zeros_mode = self.zeros_mode
+        in_dtype = self.in_dtype
+        group_size = self.group_size
+
+        @T.macro
+        def _normal_fast_dequant_impl(
+            compressed_weight_local: T.Buffer,
+            dequant_weight_local: T.Buffer,
+            scale_buffer: T.Buffer,
+            zeros_buffer: T.Buffer,
+            qzeros_buffer: T.Buffer,
+        ):
+            if not with_scaling:
+                T.call_extern(
+                    func_name,
+                    T.address_of(compressed_weight_local[0]),
+                    T.address_of(dequant_weight_local[0]),
+                    dtype=in_dtype,
+                )
+            elif not with_zeros:
+                T.call_extern(
+                    func_name,
+                    T.address_of(compressed_weight_local[0]),
+                    T.address_of(dequant_weight_local[0]),
+                    T.address_of(scale_buffer[pid_n * stride_n, k * stride_k // group_size]),
+                    dtype=in_dtype,
+                )
+            elif zeros_mode in ["original", "rescale"]:
+                T.call_extern(
+                    func_name,
+                    T.address_of(compressed_weight_local[0]),
+                    T.address_of(dequant_weight_local[0]),
+                    T.address_of(scale_buffer[pid_n * stride_n, k * stride_k // group_size]),
+                    T.address_of(zeros_buffer[pid_n * stride_n, k * stride_k // group_size]),
+                    dtype=in_dtype,
+                )
+            elif zeros_mode == "quantized":
+                T.call_extern(
+                    func_name,
+                    T.address_of(compressed_weight_local[0]),
+                    T.address_of(dequant_weight_local[0]),
+                    T.address_of(scale_buffer[pid_n * stride_n, k * stride_k // group_size]),
+                    T.address_of(zeros_buffer[pid_n * stride_n, k * stride_k // group_size]),
+                    T.address_of(qzeros_buffer[k * stride_k // group_size,
+                                               pid_n * stride_n // num_elems_per_byte]),
+                    dtype=in_dtype,
+                )
+
+        return _normal_fast_dequant_impl(
             compressed_weight_local,
             dequant_weight_local,
             scale_buffer,

--- a/testing/python/operators/test_general_matmul_tilelang_kernel.py
+++ b/testing/python/operators/test_general_matmul_tilelang_kernel.py
@@ -570,6 +570,19 @@ def test_matmul_blocked_dequant_with_default():
         1024, 1024, 1024, source_format="uint", bit=4, with_scaling=True)
     assert_matmul_blocked_dequant_with_default_correctness(
         1024, 1024, 1024, source_format="uint", bit=4, with_scaling=True, with_zeros=True)
+    assert_matmul_blocked_dequant_with_default_correctness(
+        1024, 1024, 1024, source_format="uint", bit=4, fast_decoding=True)
+    assert_matmul_blocked_dequant_with_default_correctness(
+        1024, 1024, 1024, source_format="uint", bit=4, with_scaling=True, fast_decoding=True)
+    assert_matmul_blocked_dequant_with_default_correctness(
+        1024,
+        1024,
+        1024,
+        source_format="uint",
+        bit=4,
+        with_scaling=True,
+        with_zeros=True,
+        fast_decoding=True)
 
 
 if __name__ == "__main__":

--- a/testing/python/operators/test_general_matmul_tilelang_kernel.py
+++ b/testing/python/operators/test_general_matmul_tilelang_kernel.py
@@ -520,7 +520,7 @@ def assert_matmul_blocked_dequant_with_default_correctness(
     mod(*permuted_inputs)
 
     print(permuted_inputs[-1])
-    
+
     ref_result = torch.matmul(inputs[0], inputs[1].t().to(torch.float16))
 
     print(ref_result)

--- a/testing/python/operators/test_general_matmul_tilelang_scheduler.py
+++ b/testing/python/operators/test_general_matmul_tilelang_scheduler.py
@@ -78,7 +78,7 @@ def assert_dequantize_scheduler_simplify(
 
     simplified = MatmulDequantizeScheduler.Simplify(matmul)
     print(simplified)
-    is_equal = structural_equal(matmul, simplified)
+    is_equal = structural_equal(matmul, simplified) # noqa: F841
     assert simplified is not None, "Simplify should return a schedule"
 
 

--- a/testing/python/operators/test_general_matmul_tilelang_scheduler.py
+++ b/testing/python/operators/test_general_matmul_tilelang_scheduler.py
@@ -78,7 +78,7 @@ def assert_dequantize_scheduler_simplify(
 
     simplified = MatmulDequantizeScheduler.Simplify(matmul)
     print(simplified)
-    is_equal = structural_equal(matmul, simplified) # noqa: F841
+    is_equal = structural_equal(matmul, simplified)  # noqa: F841
     assert simplified is not None, "Simplify should return a schedule"
 
 

--- a/testing/python/tilelang/test_tilelang_dequantize_gemm.py
+++ b/testing/python/tilelang/test_tilelang_dequantize_gemm.py
@@ -437,4 +437,6 @@ def test_assert_tl_matmul_with_ladder_weight_only_transform_block_reduce_int4():
 
 
 if __name__ == "__main__":
-    bitblas.testing.main()
+    # bitblas.testing.main()
+    run_gemm(256, 256, 256, "float16", "float16", "float16", 128, 128, 32, num_threads=128)
+

--- a/testing/python/tilelang/test_tilelang_dequantize_gemm.py
+++ b/testing/python/tilelang/test_tilelang_dequantize_gemm.py
@@ -439,4 +439,3 @@ def test_assert_tl_matmul_with_ladder_weight_only_transform_block_reduce_int4():
 if __name__ == "__main__":
     # bitblas.testing.main()
     run_gemm(256, 256, 256, "float16", "float16", "float16", 128, 128, 32, num_threads=128)
-


### PR DESCRIPTION
This pull request includes several changes aimed at cleaning up debug prints, updating submodule commits, and improving test coverage in the `bitblas` and `testing` modules.

### Codebase cleanup:

* [`bitblas/ops/general_matmul/tilelang/dequantize/block_primitive_tensorcore.py`](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L404-L422): Removed multiple debug `print` statements from the `_normal_dequant_impl` function to reduce console clutter. [[1]](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L404-L422) [[2]](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L432) [[3]](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L442) [[4]](diffhunk://#diff-a8892dadc6b24432ac9785d3a5def29c81b6e347d7b1b76b2cb7f037ce378022L452)

### Submodule updates:

* [`3rdparty/tvm`](diffhunk://#diff-fa909c93fe94e9aa04c9e7f19e5754a2bb274678ad5c6275ee4bf54c6f9b1066L1-R1): Updated the submodule commit to the latest version.

### Test improvements:

* [`testing/python/operators/test_general_matmul_tilelang_kernel.py`](diffhunk://#diff-052c67c47659338f3612e7c47384c54f88929e9b32c40d9e797b3f5307ff3896R569-R572): Added new test cases for `assert_matmul_blocked_dequant_with_default_correctness` to cover scenarios with scaling and zeros.
* [`testing/python/operators/test_general_matmul_tilelang_kernel.py`](diffhunk://#diff-052c67c47659338f3612e7c47384c54f88929e9b32c40d9e797b3f5307ff3896R523-R530): Adjusted the tolerance levels in `assert_matmul_blocked_dequant_with_default_correctness` to `atol=1e2` for better test accuracy.
* [`testing/python/operators/test_general_matmul_tilelang_scheduler.py`](diffhunk://#diff-9ec5249617821fa5b835ab94a80fa9b3e44a15ce612a49534cbe07770f5375aeL81-R81): Added a `noqa` comment to suppress linter warnings for an unused variable in `assert_dequantize_scheduler_simplify`.
* [`testing/python/tilelang/test_tilelang_dequantize_gemm.py`](diffhunk://#diff-d5dc9a5d7a85aec8ba220df42c16de4af47027bd6e1d2f920a2c3c6ac327dc02L440-R441): Commented out the main test runner and added a specific test invocation for `run_gemm`.