### PR TITLE
[Dev] Refactor codebase to save import time

### DIFF
--- a/benchmark/operators/benchmark_bitblas_matmul.py
+++ b/benchmark/operators/benchmark_bitblas_matmul.py
@@ -1,97 +1,36 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-
+import bitblas
 from bitblas.utils.target_detector import auto_detect_nvidia_target
 from bitblas import Matmul, MatmulConfig
 import argparse
 import json
 
+bitblas.set_log_level("DEBUG")
 # Initialize the parser
-parser = argparse.ArgumentParser(
-    description="Benchmark BitBLAS int4 on a specific target."
-)
+parser = argparse.ArgumentParser(description="Benchmark BitBLAS int4 on a specific target.")
 
 # Add arguments to the parser
 parser.add_argument(
     "--target",
     type=str,
     default=auto_detect_nvidia_target(),
-    help="Specify the target device for benchmarking."
-)
-parser.add_argument(
-    "--group_size",
-    type=int,
-    default=None,
-    help="Group size for grouped quantization."
-)
-parser.add_argument(
-    "--A_dtype",
-    type=str,
-    default="float16",
-    choices=["float16", "int8"], 
-    help="Data type of activation A."
-)
-parser.add_argument(
-    "--W_dtype",
-    type=str,
-    default="int4",
-    choices=["float16", "int32", "int8", "int4", "int2", "int1", "nf4", "fp4_e2m1"],
-    help="Data type of weight W."
-)
-parser.add_argument(
-    "--accum_dtype",
-    type=str,
-    default="float16",
-    choices=["float16", "int32"],  # Assuming these are the valid choices
-    help="Data type for accumulation."
-)
-parser.add_argument(
-    "--out_dtype",
-    type=str,
-    default="float16",
-    choices=["float16", "float32", "int32", "int8"],  # Assuming these are the valid choices
-    help="Data type for output."
-)
-parser.add_argument(
-    "--layout",
-    type=str,
-    default="nt",
-    choices=["nt", "nn"],  # Assuming these are the valid choices
-    help="Matrix layout, 'nt' for non-transpose A and transpose W."
-)
-parser.add_argument(
-    "--with_bias",
-    action="store_true",
-    help="Include bias in the benchmark."
-)
-parser.add_argument(
-    "--with_scaling",
-    action="store_true",
-    help="Include scaling factor in the quantization."
-)
-parser.add_argument(
-    "--with_zeros",
-    action="store_true",
-    help="Include zeros in the quantization."
-)
-parser.add_argument(
-    "--zeros_mode",
-    type=str,
-    default=None,
-    choices=["original", "rescale", "quantized"],  # Replace with actual modes if applicable
-    help="Specify the mode for calculating zeros."
-)
+    help="Specify the target device for benchmarking.")
 
 parser.add_argument(
     "--backend",
     type=str,
-    default="tl",
+    default="tir",
     choices=["tir", "tl"],  # Replace with actual modes if applicable
-    help="Specify the mode for calculating zeros."
-)
+    help="Specify the mode for calculating zeros.")
 
+# [A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode]
 default_test_shapes = json.dumps([
-    ["MatmulConfig", "Matmul", [1, 16384, 16384, "float16", "int4", "float16", "float16", "nt", False, None, False, False, None]]
+    # ["MatmulConfig", "Matmul", [1, 16384, 16384, "float16", "int4", "float16", "float16", "nt", False, None, False, False, None]]
+    [
+        "MatmulConfig", "Matmul",
+        [1, 16384, 16384, "int8", "int8", "int32", "int32", "nt", False, None, False, False, None]
+    ]
 ])
 
 parser.add_argument(
@@ -106,23 +45,10 @@ args = parser.parse_args()
 
 # Assign arguments to variables
 target = args.target
-group_size = args.group_size
-A_dtype = args.A_dtype
-W_dtype = args.W_dtype
-accum_dtype = args.accum_dtype
-out_dtype = args.out_dtype
-layout = args.layout
-with_bias = args.with_bias
-with_scaling = args.with_scaling
-with_zeros = args.with_zeros
-zeros_mode = args.zeros_mode
 backend = args.backend
 
 parsed_test_shapes = json.loads(args.test_shapes)
-name_to_class = {
-    "MatmulConfig": MatmulConfig,
-    "Matmul": Matmul
-}
+name_to_class = {"MatmulConfig": MatmulConfig, "Matmul": Matmul}
 
 test_shapes = []
 for item in parsed_test_shapes:
@@ -139,12 +65,13 @@ benchmark_sets.extend(test_shapes)
 benchmark_results = {}
 for config, operator, input_args in benchmark_sets:
     config = config(*input_args)
+    print(f"Running benchmark for {operator.__name__} with config: {config}")
     op_inst = operator(config, target=target, enable_tuning=True, backend=backend)
     kernel_latency = op_inst.profile_latency()
     if op_inst.input_transform is not None:
         kernel_latency += op_inst.ladder_permutate_a.profile_latency()
 
-    print("Time cost is: {:.3f} ms".format(kernel_latency))
+    print("Time cost of {} is: {:.3f} ms".format(str(config), kernel_latency))
 
     profile_config = {
         f"{operator.__name__}-{'-'.join([str(i) for i in input_args])}": {
@@ -168,7 +95,9 @@ for config, values in benchmark_results.items():
     input_args = "-".join(args[1:])
     col_widths[0] = max((max(len(str(headers[0])), len(func_name)) + 2), col_widths[0])
     col_widths[1] = max((max(len(str(headers[1])), len(input_args)) + 2, col_widths[1]))
-    col_widths[2] = max(max(len(str(headers[2])), len(f"{values['BitBLAS_top20_latency']:.3f} ms")) + 2, col_widths[2])
+    col_widths[2] = max(
+        max(len(str(headers[2])), len(f"{values['BitBLAS_top20_latency']:.3f} ms")) + 2,
+        col_widths[2])
     break
 
 for i, header in enumerate(headers):

--- a/benchmark/operators/benchmark_bitblas_matmul.py
+++ b/benchmark/operators/benchmark_bitblas_matmul.py
@@ -4,138 +4,132 @@
 from bitblas.utils.target_detector import auto_detect_nvidia_target
 from bitblas import Matmul, MatmulConfig
 import argparse
+import json
 
-  
-# Initialize the parser  
-parser = argparse.ArgumentParser(  
-    description="Benchmark BitBLAS int4 on a specific target."  
-)  
-  
-# Add arguments to the parser  
-parser.add_argument(  
-    "--target",  
-    type=str,  
-    default=auto_detect_nvidia_target(),  
-    help="Specify the target device for benchmarking."  
-)  
-parser.add_argument(  
-    "--group_size",  
-    type=int,  
-    default=None,  
-    help="Group size for grouped quantization."  
-)  
-parser.add_argument(  
-    "--A_dtype",  
-    type=str,  
-    default="float16",  
-    choices=["float16", "float32", "float64", "int32", "int8"],  # Assuming these are the valid choices  
-    help="Data type of activation A."  
-)  
-parser.add_argument(  
-    "--W_dtype",  
-    type=str,  
-    default="int4",  
-    choices=["float16", "float32", "float64", "int32", "int8", "int4", "int2", "int1", "nf4", "fp4_e2m1"],  # Assuming these are the valid choices  
-    help="Data type of weight W."  
-)  
-parser.add_argument(  
-    "--accum_dtype",  
-    type=str,  
-    default="float16",  
-    choices=["float16", "int32"],  # Assuming these are the valid choices  
-    help="Data type for accumulation."  
-)  
-parser.add_argument(  
-    "--out_dtype",  
-    type=str,  
-    default="float16",  
-    choices=["float16", "float32", "int32", "int8"],  # Assuming these are the valid choices  
-    help="Data type for output."  
-)  
-parser.add_argument(  
-    "--layout",  
-    type=str,  
-    default="nt",  
-    choices=["nt", "nn"],  # Assuming these are the valid choices  
-    help="Matrix layout, 'nt' for non-transpose A and transpose W."  
-)  
-parser.add_argument(  
-    "--with_bias",  
-    action="store_true",  
-    help="Include bias in the benchmark."  
-)  
-parser.add_argument(  
-    "--with_scaling",  
-    action="store_true",  
-    help="Include scaling factor in the quantization."  
-)  
-parser.add_argument(  
-    "--with_zeros",  
-    action="store_true",  
-    help="Include zeros in the quantization."  
-)  
-parser.add_argument(  
-    "--zeros_mode",  
-    type=str,  
-    default=None,  
-    choices=["original", "rescale", "quantized"],  # Replace with actual modes if applicable  
-    help="Specify the mode for calculating zeros."  
-)  
-  
-# Parse the arguments  
-args = parser.parse_args()  
-  
-# Assign arguments to variables  
-target = args.target  
-group_size = args.group_size  
-A_dtype = args.A_dtype  
-W_dtype = args.W_dtype  
-accum_dtype = args.accum_dtype  
-out_dtype = args.out_dtype  
-layout = args.layout  
-with_bias = args.with_bias  
-group_size = args.group_size  
-with_scaling = args.with_scaling  
-with_zeros = args.with_zeros  
-zeros_mode = args.zeros_mode 
+# Initialize the parser
+parser = argparse.ArgumentParser(
+    description="Benchmark BitBLAS int4 on a specific target."
+)
 
-test_shapes = [
-    # square test
-    (MatmulConfig, Matmul, (1, 16384, 16384, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    # BLOOM-176B
-    (MatmulConfig, Matmul, (1, 43008, 14336, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (1, 14336, 14336, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (1, 57344, 14336, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (1, 14336, 57344, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    # # OPT-65B
-    (MatmulConfig, Matmul, (1, 9216, 9216, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (1, 36864, 9216, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (1, 9216, 36864, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (1, 22016, 8192, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    # # LLAMA-70B/65B
-    (MatmulConfig, Matmul, (1, 8192, 22016, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (1, 8192, 8192, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (1, 28672, 8192, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (1, 8192, 28672, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    
-    # square test
-    (MatmulConfig, Matmul, (16384, 16384, 16384, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    # BLOOM-176B
-    (MatmulConfig, Matmul, (8192, 43008, 14336, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (8192, 14336, 14336, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (8192, 57344, 14336, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (8192, 14336, 57344, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    # # OPT-65B
-    (MatmulConfig, Matmul, (8192, 9216, 9216, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (8192, 36864, 9216, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (8192, 9216, 36864, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (8192, 22016, 8192, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    # # LLAMA-70B/65B
-    (MatmulConfig, Matmul, (8192, 8192, 22016, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (8192, 8192, 8192, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (8192, 28672, 8192, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-    (MatmulConfig, Matmul, (8192, 8192, 28672, A_dtype, W_dtype, out_dtype, accum_dtype, layout, with_bias, group_size, with_scaling, with_zeros, zeros_mode)),
-]
+# Add arguments to the parser
+parser.add_argument(
+    "--target",
+    type=str,
+    default=auto_detect_nvidia_target(),
+    help="Specify the target device for benchmarking."
+)
+parser.add_argument(
+    "--group_size",
+    type=int,
+    default=None,
+    help="Group size for grouped quantization."
+)
+parser.add_argument(
+    "--A_dtype",
+    type=str,
+    default="float16",
+    choices=["float16", "int8"], 
+    help="Data type of activation A."
+)
+parser.add_argument(
+    "--W_dtype",
+    type=str,
+    default="int4",
+    choices=["float16", "int32", "int8", "int4", "int2", "int1", "nf4", "fp4_e2m1"],
+    help="Data type of weight W."
+)
+parser.add_argument(
+    "--accum_dtype",
+    type=str,
+    default="float16",
+    choices=["float16", "int32"],  # Assuming these are the valid choices
+    help="Data type for accumulation."
+)
+parser.add_argument(
+    "--out_dtype",
+    type=str,
+    default="float16",
+    choices=["float16", "float32", "int32", "int8"],  # Assuming these are the valid choices
+    help="Data type for output."
+)
+parser.add_argument(
+    "--layout",
+    type=str,
+    default="nt",
+    choices=["nt", "nn"],  # Assuming these are the valid choices
+    help="Matrix layout, 'nt' for non-transpose A and transpose W."
+)
+parser.add_argument(
+    "--with_bias",
+    action="store_true",
+    help="Include bias in the benchmark."
+)
+parser.add_argument(
+    "--with_scaling",
+    action="store_true",
+    help="Include scaling factor in the quantization."
+)
+parser.add_argument(
+    "--with_zeros",
+    action="store_true",
+    help="Include zeros in the quantization."
+)
+parser.add_argument(
+    "--zeros_mode",
+    type=str,
+    default=None,
+    choices=["original", "rescale", "quantized"],  # Replace with actual modes if applicable
+    help="Specify the mode for calculating zeros."
+)
+
+parser.add_argument(
+    "--backend",
+    type=str,
+    default="tl",
+    choices=["tir", "tl"],  # Replace with actual modes if applicable
+    help="Specify the mode for calculating zeros."
+)
+
+default_test_shapes = json.dumps([
+    ["MatmulConfig", "Matmul", [1, 16384, 16384, "float16", "int4", "float16", "float16", "nt", False, None, False, False, None]]
+])
+
+parser.add_argument(
+    "--test_shapes",
+    type=str,
+    default=default_test_shapes,
+    help="JSON string defining test shapes. Example format: '[[\"MatmulConfig\", \"Matmul\", [1,16384,16384,\"float16\",\"int4\",\"float16\",\"float16\",\"nt\",false,null,false,false,null]]]'"
+)
+
+# Parse the arguments
+args = parser.parse_args()
+
+# Assign arguments to variables
+target = args.target
+group_size = args.group_size
+A_dtype = args.A_dtype
+W_dtype = args.W_dtype
+accum_dtype = args.accum_dtype
+out_dtype = args.out_dtype
+layout = args.layout
+with_bias = args.with_bias
+with_scaling = args.with_scaling
+with_zeros = args.with_zeros
+zeros_mode = args.zeros_mode
+backend = args.backend
+
+parsed_test_shapes = json.loads(args.test_shapes)
+name_to_class = {
+    "MatmulConfig": MatmulConfig,
+    "Matmul": Matmul
+}
+
+test_shapes = []
+for item in parsed_test_shapes:
+    config_class_name, operator_class_name, input_args = item
+    config_class = name_to_class[config_class_name]
+    operator_class = name_to_class[operator_class_name]
+    test_shapes.append((config_class, operator_class, tuple(input_args)))
 
 benchmark_sets = []
 benchmark_sets.extend(test_shapes)
@@ -145,11 +139,11 @@ benchmark_sets.extend(test_shapes)
 benchmark_results = {}
 for config, operator, input_args in benchmark_sets:
     config = config(*input_args)
-    matmul = operator(config, target=target, enable_tuning=True)
-    kernel_latency = matmul.profile_latency()
-    if matmul.input_transform is not None:
-        kernel_latency += matmul.ladder_permutate_a.profile_latency()
-    
+    op_inst = operator(config, target=target, enable_tuning=True, backend=backend)
+    kernel_latency = op_inst.profile_latency()
+    if op_inst.input_transform is not None:
+        kernel_latency += op_inst.ladder_permutate_a.profile_latency()
+
     print("Time cost is: {:.3f} ms".format(kernel_latency))
 
     profile_config = {
@@ -160,7 +154,7 @@ for config, operator, input_args in benchmark_sets:
 
     benchmark_results.update(profile_config)
 
-# Define headers for the table  
+# Define headers for the table
 headers = [
     "PrimFunc",
     "Input Arguments",

--- a/bitblas/base/arch/__init__.py
+++ b/bitblas/base/arch/__init__.py
@@ -1,15 +1,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 from .arch_base import TileDevice
-from .cuda import *
-from .cpu import *
-from .cdna import *
+from .cuda import CUDA
+from .cpu import CPU
+from .cdna import CDNA
 from typing import Union
+from tvm.target import Target
 
 
-def get_arch(target: Union[str, tvm.target.Target] = "cuda") -> TileDevice:
+def get_arch(target: Union[str, Target] = "cuda") -> TileDevice:
     if isinstance(target, str):
-        target = tvm.target.Target(target)
+        target = Target(target)
 
     if target.kind.name == "cuda":
         return CUDA(target)
@@ -27,57 +28,14 @@ def auto_infer_current_arch() -> TileDevice:
     return get_arch("cuda")
 
 
-def is_cpu_arch(arch: TileDevice) -> bool:
-    return isinstance(arch, CPU)
-
-
-def is_cuda_arch(arch: TileDevice) -> bool:
-    return isinstance(arch, CUDA)
-
-
-def is_ampere_arch(arch: TileDevice) -> bool:
-    conditions = [True]
-    conditions.append(is_cuda_arch(arch))
-    conditions.append(arch.sm_version >= 80 and arch.sm_version < 90)
-    return all(conditions)
-
-
-def is_volta_arch(arch: TileDevice) -> bool:
-    conditions = [True]
-    conditions.append(is_cuda_arch(arch))
-    conditions.append(arch.sm_version >= 70)
-    conditions.append(arch.sm_version < 80)
-    return all(conditions)
-
-
-def is_cdna_arch(arch: TileDevice) -> bool:
-    return isinstance(arch, CDNA)
-
-
-def has_mma_support(arch: TileDevice) -> bool:
-    conditions = [True]
-    conditions.append(is_cuda_arch(arch))
-    conditions.append(arch.sm_version >= 80)
-    return all(conditions)
-
-
-def is_tensorcore_supported_precision(in_dtype: str, accum_dtype: str, arch: TileDevice) -> bool:
-    volta_tensorcore_supported = [
-        ("float16", "float32"),
-        ("float16", "float16"),
-    ]
-    ampere_tensorcore_supported = [
-        ("float16", "float32"),
-        ("float16", "float16"),
-        ("int8", "int32"),
-        ("int4", "int32"),
-        ("int2", "int32"),
-        ("int1", "int32"),
-    ]
-
-    if is_volta_arch(arch):
-        return (in_dtype, accum_dtype) in volta_tensorcore_supported
-    elif is_ampere_arch(arch):
-        return (in_dtype, accum_dtype) in ampere_tensorcore_supported
-    else:
-        raise ValueError(f"Unsupported architecture: {arch}")
+from .cpu import is_cpu_arch  # noqa: F401
+from .cuda import (
+    is_cuda_arch,  # noqa: F401
+    is_volta_arch,  # noqa: F401
+    is_ampere_arch,  # noqa: F401
+    is_ada_arch,  # noqa: F401
+    is_hopper_arch,  # noqa: F401
+    is_tensorcore_supported_precision,  # noqa: F401
+    has_mma_support,  # noqa: F401
+)
+from .cdna import is_cdna_arch  # noqa: F401

--- a/bitblas/base/arch/cdna.py
+++ b/bitblas/base/arch/cdna.py
@@ -7,6 +7,10 @@ from .arch_base import TileDevice
 from typing import List, Union
 
 
+def is_cdna_arch(arch: TileDevice) -> bool:
+    return isinstance(arch, CDNA)
+
+
 class CDNA(TileDevice):
 
     def __init__(self, target: Union[Target, str]):

--- a/bitblas/base/arch/cpu.py
+++ b/bitblas/base/arch/cpu.py
@@ -6,6 +6,10 @@ from tvm.target import Target
 from .arch_base import TileDevice
 
 
+def is_cpu_arch(arch: TileDevice) -> bool:
+    return isinstance(arch, CPU)
+
+
 # For LLVM Backend, we do not provide the detailed information of the CPU
 # As the LLVM backend do not required tuning, just maintain the consistency
 class CPU(TileDevice):

--- a/bitblas/base/arch/cuda.py
+++ b/bitblas/base/arch/cuda.py
@@ -57,6 +57,7 @@ volta_tensorcore_supported = [
     ("float16", "float16"),
 ]
 ampere_tensorcore_supported = [
+    ("bfloat16", "float32"),
     ("float16", "float32"),
     ("float16", "float16"),
     ("int8", "int32"),
@@ -65,6 +66,7 @@ ampere_tensorcore_supported = [
     ("int1", "int32"),
 ]
 ada_tensorcore_supported = [
+    ("bfloat16", "float32"),
     ("float16", "float32"),
     ("float16", "float16"),
     ("int8", "int32"),

--- a/bitblas/base/base_scheduler.py
+++ b/bitblas/base/base_scheduler.py
@@ -113,6 +113,9 @@ class BaseScheduler(ABC):
     ) -> PrimFunc:
         pass
 
+    def get_hint_type(self) -> str:
+        raise NotImplementedError("Get Hint type is not implemented")
+  
     def serialize_hints_to_configs(self, hints: List[Hint]) -> List[BaseTLHint]:
         # Convert Roller Hints to TileLang Hints
         raise NotImplementedError("Serialization of hints to configs is not implemented")

--- a/bitblas/base/base_scheduler.py
+++ b/bitblas/base/base_scheduler.py
@@ -115,7 +115,7 @@ class BaseScheduler(ABC):
 
     def get_hint_type(self) -> str:
         raise NotImplementedError("Get Hint type is not implemented")
-  
+
     def serialize_hints_to_configs(self, hints: List[Hint]) -> List[BaseTLHint]:
         # Convert Roller Hints to TileLang Hints
         raise NotImplementedError("Serialization of hints to configs is not implemented")

--- a/bitblas/base/roller/policy/tensorcore.py
+++ b/bitblas/base/roller/policy/tensorcore.py
@@ -328,9 +328,9 @@ class TensorCorePolicy(DefaultPolicy):
         # TODO: This is a dummy mul which avoid reusing some shared memory.
         # Should be removed in the future.
         if td.smem_cost > (self.arch.smem_cap):
-            info_message = f"Tile Dict: {td.output_tile} Shared memory exceeds the static capacity," \
+            debug_message = f"Tile Dict: {td.output_tile} Shared memory exceeds the static capacity," \
                 " use dynamic shared memory."
-            logger.info(info_message)
+            logger.debug(debug_message)
             codegen_dict.shared_scope = "shared.dyn"
 
         codegen_dict.shared_scope = "shared.dyn"

--- a/bitblas/base/utils.py
+++ b/bitblas/base/utils.py
@@ -222,7 +222,7 @@ def apply_and_build_parallel(func,
                              arch,
                              num_repeats=3,
                              max_workers=10,
-                             timeout=30,
+                             timeout=60,
                              data_distribution="uniform") -> CompileResult:
     cpresults = []
 

--- a/bitblas/base/utils.py
+++ b/bitblas/base/utils.py
@@ -262,6 +262,11 @@ def apply_and_build_parallel(func,
             code = tensor_remove_make_int2(code)
             return code
 
+        # assume index_map to be registered
+        from tvm.tir.tensor_intrin.cuda import (
+            get_mma_intrin_group,  # noqa: F401
+        )
+
         with tvm.transform.PassContext(config={
                 "tir.use_async_copy": True,
                 "tir.disable_cse_tir": True,

--- a/bitblas/base/utils.py
+++ b/bitblas/base/utils.py
@@ -262,11 +262,6 @@ def apply_and_build_parallel(func,
             code = tensor_remove_make_int2(code)
             return code
 
-        # assume index_map to be registered
-        from tvm.tir.tensor_intrin.cuda import (
-            get_mma_intrin_group,  # noqa: F401
-        )
-
         with tvm.transform.PassContext(config={
                 "tir.use_async_copy": True,
                 "tir.disable_cse_tir": True,

--- a/bitblas/gpu/__init__.py
+++ b/bitblas/gpu/__init__.py
@@ -4,6 +4,7 @@
 GPU-generic schedule rules.
 For CUDA/ROCm/Vulkan/Metal-specific rules, use `tvm.dlight.cuda/rocm/vulkan/metal` instead
 """
+
 from .fallback import Fallback  # noqa: F401
 from .element_wise import ElementWise  # noqa: F401
 from .gemv import GEMV  # noqa: F401

--- a/bitblas/ops/general_matmul/tilelang/dense/gemv_simt.py
+++ b/bitblas/ops/general_matmul/tilelang/dense/gemv_simt.py
@@ -23,6 +23,8 @@ class GemvFineGrainSIMTScheduler(MatmulSIMTBaseScheduler):
     reduce_thread: int = 16
 
     class TLHint(BaseTLHint):
+        
+        hint_type: str = "GemvFineGrainSIMTScheduler"
 
         def __init__(self):
             super().__init__()
@@ -55,6 +57,9 @@ class GemvFineGrainSIMTScheduler(MatmulSIMTBaseScheduler):
                     f"n_partition: {self.n_partition}, "
                     f"reduce_thread: {self.reduce_thread}, "
                     "}")
+
+    def get_hint_type(self):
+        return self.TLHint.hint_type
 
     def serialize_hints_to_configs(self, hints: List[Hint]):
         configs = []

--- a/bitblas/ops/general_matmul/tilelang/dense/gemv_simt.py
+++ b/bitblas/ops/general_matmul/tilelang/dense/gemv_simt.py
@@ -23,7 +23,7 @@ class GemvFineGrainSIMTScheduler(MatmulSIMTBaseScheduler):
     reduce_thread: int = 16
 
     class TLHint(BaseTLHint):
-        
+
         hint_type: str = "GemvFineGrainSIMTScheduler"
 
         def __init__(self):

--- a/bitblas/ops/general_matmul/tilelang/dense/matmul.py
+++ b/bitblas/ops/general_matmul/tilelang/dense/matmul.py
@@ -146,8 +146,14 @@ class MatmulScheduler(MatmulBaseParams):
                 self.matmul_int4_fine_grain_scheduler,
                 self.matmul_int4_weight_propagation_scheduler,
         ]:
-            if isinstance(hint, scheduler.TLHint):
-                return scheduler
+            try:
+                scheduler_hint_type = scheduler.get_hint_type()
+                if scheduler_hint_type == hint.hint_type:
+                    return scheduler
+            except NotImplementedError:
+                raise ValueError(
+                    f"get_hint_type() is not implemented for {type(scheduler)}")
+
         raise ValueError(f"Unsupported hint type: {type(hint)}")
 
     def with_default_config(self, arch: Optional[TileDevice] = None) -> PrimFunc:

--- a/bitblas/ops/general_matmul/tilelang/dense/matmul.py
+++ b/bitblas/ops/general_matmul/tilelang/dense/matmul.py
@@ -150,9 +150,8 @@ class MatmulScheduler(MatmulBaseParams):
                 scheduler_hint_type = scheduler.get_hint_type()
                 if scheduler_hint_type == hint.hint_type:
                     return scheduler
-            except NotImplementedError:
-                raise ValueError(
-                    f"get_hint_type() is not implemented for {type(scheduler)}")
+            except NotImplementedError as e:
+                raise ValueError(f"get_hint_type() is not implemented for {type(scheduler)}") from e
 
         raise ValueError(f"Unsupported hint type: {type(hint)}")
 

--- a/bitblas/ops/general_matmul/tilelang/dense/matmul_simt.py
+++ b/bitblas/ops/general_matmul/tilelang/dense/matmul_simt.py
@@ -74,6 +74,8 @@ class MatmulFineGrainSIMTScheduler(MatmulSIMTBaseScheduler):
 
     class TLHint(BaseTLHint):
 
+        hint_type: str = "MatmulFineGrainSIMTScheduler"
+
         def __init__(self):
             super().__init__()
 
@@ -118,6 +120,9 @@ class MatmulFineGrainSIMTScheduler(MatmulSIMTBaseScheduler):
                     f"thread_col_tiles: {self.thread_col_tiles}, "
                     f"chunk: {self.chunk}"
                     "}")
+
+    def get_hint_type(self):
+        return self.TLHint.hint_type
 
     def serialize_hints_to_configs(self, hints: List[Hint]):
         configs = []

--- a/bitblas/ops/general_matmul/tilelang/dense/matmul_tensorcore.py
+++ b/bitblas/ops/general_matmul/tilelang/dense/matmul_tensorcore.py
@@ -84,7 +84,7 @@ class MatmulBlockScheduler(MatmulBaseScheduler):
     enable_rasterization: bool = False  # Enhance L2 Locality
 
     class TLHint(BaseTLHint):
-        
+
         hint_type = "MatmulBlockScheduler"
 
         def __init__(self):
@@ -704,7 +704,8 @@ class MatmulWeightPropagationScheduler(MatmulFineGrainScheduler):
                                 micro_size_x,
                                 micro_size_k,
                         ):
-                            A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x), ko * (block_K // micro_size_k), ii, kk]
+                            A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x),
+                                                       ko * (block_K // micro_size_k), ii, kk]
                     else:
                         T.copy(A[by * block_M, ko * block_K], A_shared)
 
@@ -789,14 +790,6 @@ class MatmulWeightPropagationScheduler(MatmulFineGrainScheduler):
     @property
     def is_b_smooth(self):
         return self.weight_transform_kind > TransformKind.NonTransform
-
-    def __post_init__(self):
-        # Validate the matrix transpose settings
-        assert self.trans_A is False, "Currently only support Matrix A not transposed"
-        assert self.trans_B is True, "Currently only support Matrix B transposed"
-        assert self.weight_transform_kind > TransformKind.NonTransform, "Weight Transform Kind is required"
-
-        return
 
 
 @dataclass
@@ -943,7 +936,7 @@ class MatmulINT4FineGrainScheduler(MatmulFineGrainScheduler):
                 # Apply memory layout optimizations
                 T.annotate_layout({
                     A_shared: make_swizzle_layout(A_shared),
-                    B_shared: make_swizzle_layout(B_shared, is_smooth=True),
+                    B_shared: make_swizzle_layout(B_shared),
                 })
 
                 # Optional rasterization for L2 locality enhancement
@@ -1016,7 +1009,7 @@ class MatmulINT4WeightPropagationScheduler(MatmulWeightPropagationScheduler):
 
     class TLHint(MatmulWeightPropagationScheduler.TLHint):
         hint_type: str = "MatmulINT4WeightPropagationScheduler"
-    
+
     def get_roller_configs(self, arch: TileDevice = None, topk: int = 10):
         layout = f"{'t' if self.trans_A else 'n'}{'t' if self.trans_B else 'n'}"
         M = self.M
@@ -1194,7 +1187,8 @@ class MatmulINT4WeightPropagationScheduler(MatmulWeightPropagationScheduler):
                                 micro_size_x,
                                 micro_size_k,
                         ):
-                            A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x), ko * (block_K // micro_size_k), ii, kk]
+                            A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x),
+                                                       ko * (block_K // micro_size_k), ii, kk]
                     else:
                         T.copy(A[by * block_M, ko * block_K], A_shared)
 

--- a/bitblas/ops/general_matmul/tilelang/dense/matmul_tensorcore.py
+++ b/bitblas/ops/general_matmul/tilelang/dense/matmul_tensorcore.py
@@ -84,6 +84,8 @@ class MatmulBlockScheduler(MatmulBaseScheduler):
     enable_rasterization: bool = False  # Enhance L2 Locality
 
     class TLHint(BaseTLHint):
+        
+        hint_type = "MatmulBlockScheduler"
 
         def __init__(self):
             super().__init__()
@@ -160,6 +162,9 @@ class MatmulBlockScheduler(MatmulBaseScheduler):
         ]
         configs = [{**c, 'num_stages': num_stages} for c in configs]
         return configs
+
+    def get_hint_type(self):
+        return self.TLHint.hint_type
 
     def serialize_hints_to_configs(self, hints: List[Hint]):
         configs = []
@@ -274,6 +279,8 @@ class MatmulFineGrainScheduler(MatmulBaseScheduler):
 
     class TLHint(BaseTLHint):
 
+        hint_type: str = "MatmulFineGrainScheduler"
+
         def __init__(self):
             super().__init__()
 
@@ -331,6 +338,9 @@ class MatmulFineGrainScheduler(MatmulBaseScheduler):
                     f"num_stages={self.num_stages},"
                     f"enable_rasterization={self.enable_rasterization}"
                     "}")
+
+    def get_hint_type(self):
+        return self.TLHint.hint_type
 
     def serialize_hints_to_configs(self, hints: List[Hint]):
         configs = []
@@ -555,6 +565,9 @@ class MatmulWeightPropagationScheduler(MatmulFineGrainScheduler):
     # force set default weight transform kind to LDMatrixTransform
     weight_transform_kind: TransformKind = TransformKind.LDMatrixTransform
 
+    class TLHint(MatmulFineGrainScheduler.TLHint):
+        hint_type: str = "MatmulWeightPropagationScheduler"
+
     def apply_config(
         self,
         block_row_warps=2,
@@ -573,6 +586,7 @@ class MatmulWeightPropagationScheduler(MatmulFineGrainScheduler):
         trans_A, trans_B = self.trans_A, self.trans_B
         in_dtype, out_dtype, accum_dtype = self.in_dtype, self.out_dtype, self.accum_dtype
         with_bias = self.with_bias
+        input_transform_kind, weight_transform_kind = self.input_transform_kind, self.weight_transform_kind
 
         # Calculate the micro size per warp using a helper function
         micro_size_x, micro_size_y, micro_size_k = get_mma_micro_size(in_dtype)
@@ -581,21 +595,28 @@ class MatmulWeightPropagationScheduler(MatmulFineGrainScheduler):
         block_N = block_col_warps * warp_col_tiles
         block_K = chunk
 
-        # TODO(lei): Can be generalized to analyzed from bank size
-        pad_factor = 8 if in_dtype == "float16" else 16
-
-        can_swizzle_a = block_K * DataType(in_dtype).bits == 512
-        apply_pad_a = not can_swizzle_a
-
         micro_size_x, micro_size_y, micro_size_k = get_mma_micro_size(in_dtype)
 
         # Define the shapes of matrices and shared memory buffers
-        A_shape = (M, K)
         B_shape = (N // micro_size_y, K // micro_size_k, micro_size_y, micro_size_k)
         C_shape = (M, N)
         Bias_shape = (N,)
 
-        A_shared_shape = (block_M, (block_K + pad_factor) if apply_pad_a else block_K)
+        is_a_smooth = self.is_a_smooth
+        is_b_smooth = self.is_b_smooth
+
+        if is_a_smooth:
+            A_shape = (M // micro_size_x, K // micro_size_k, micro_size_x, micro_size_k)
+            A_shared_shape = (
+                block_M // micro_size_x,
+                block_K // micro_size_k,
+                micro_size_x,
+                micro_size_k,
+            )
+        else:
+            A_shape = (M, K)
+            A_shared_shape = (block_M, block_K)
+
         B_shared_shape = (
             block_N // micro_size_y,
             block_K // micro_size_k,
@@ -634,7 +655,8 @@ class MatmulWeightPropagationScheduler(MatmulFineGrainScheduler):
             warp_row_tiles=warp_row_tiles,
             warp_col_tiles=warp_col_tiles,
             chunk=chunk,
-            transform_kind_b=self.weight_transform_kind,
+            transform_kind_a=input_transform_kind,
+            transform_kind_b=weight_transform_kind,
         )
 
         cache_write_required = self.check_require_cache()
@@ -663,8 +685,8 @@ class MatmulWeightPropagationScheduler(MatmulFineGrainScheduler):
 
                 # Apply memory layout optimizations
                 T.annotate_layout({
-                    A_shared: make_swizzle_layout(A_shared),
-                    B_shared: make_swizzle_layout(B_shared),
+                    A_shared: make_swizzle_layout(A_shared, is_smooth=is_a_smooth),
+                    B_shared: make_swizzle_layout(B_shared, is_smooth=is_b_smooth),
                 })
 
                 T.use_swizzle(panel_size=10, enable=enable_rasterization)
@@ -675,9 +697,16 @@ class MatmulWeightPropagationScheduler(MatmulFineGrainScheduler):
                 # Main matrix multiplication pipeline with multiple stages
                 for ko in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
 
-                    # Load A matrix into shared memory
-                    for i, k in T.Parallel(block_M, block_K):
-                        A_shared[i, k] = A[by * block_M + i, ko * block_K + k]
+                    if is_a_smooth:
+                        for i, k, ii, kk in T.Parallel(
+                                block_M // micro_size_x,
+                                block_K // micro_size_k,
+                                micro_size_x,
+                                micro_size_k,
+                        ):
+                            A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x), ko * (block_K // micro_size_k), ii, kk]
+                    else:
+                        T.copy(A[by * block_M, ko * block_K], A_shared)
 
                     # Load B matrix into shared memory
                     for j, k, jj, kk in T.Parallel(
@@ -753,16 +782,29 @@ class MatmulWeightPropagationScheduler(MatmulFineGrainScheduler):
 
         return self.post_process(main)
 
+    @property
+    def is_a_smooth(self):
+        return self.input_transform_kind > TransformKind.NonTransform
+
+    @property
+    def is_b_smooth(self):
+        return self.weight_transform_kind > TransformKind.NonTransform
+
     def __post_init__(self):
         # Validate the matrix transpose settings
         assert self.trans_A is False, "Currently only support Matrix A not transposed"
         assert self.trans_B is True, "Currently only support Matrix B transposed"
+        assert self.weight_transform_kind > TransformKind.NonTransform, "Weight Transform Kind is required"
 
         return
 
 
 @dataclass
 class MatmulINT4FineGrainScheduler(MatmulFineGrainScheduler):
+
+    @dataclass
+    class TLHint(MatmulFineGrainScheduler.TLHint):
+        hint_type: str = "MatmulINT4FineGrainScheduler"
 
     def get_roller_configs(self, arch: TileDevice = None, topk: int = 10):
         layout = f"{'t' if self.trans_A else 'n'}{'t' if self.trans_B else 'n'}"
@@ -972,6 +1014,9 @@ class MatmulINT4FineGrainScheduler(MatmulFineGrainScheduler):
 @dataclass
 class MatmulINT4WeightPropagationScheduler(MatmulWeightPropagationScheduler):
 
+    class TLHint(MatmulWeightPropagationScheduler.TLHint):
+        hint_type: str = "MatmulINT4WeightPropagationScheduler"
+    
     def get_roller_configs(self, arch: TileDevice = None, topk: int = 10):
         layout = f"{'t' if self.trans_A else 'n'}{'t' if self.trans_B else 'n'}"
         M = self.M
@@ -1047,10 +1092,23 @@ class MatmulINT4WeightPropagationScheduler(MatmulWeightPropagationScheduler):
         can_swizzle_a = block_K * DataType(storage_dtype).bits == 512
         apply_pad_a = not can_swizzle_a
 
+        is_a_smooth = self.is_a_smooth
+        is_b_smooth = self.is_b_smooth
+
+        if is_a_smooth:
+            A_shape = (M // micro_size_x, K // micro_size_k, micro_size_x, micro_size_k)
+            A_shared_shape = (
+                block_M // micro_size_x,
+                block_K // micro_size_k,
+                micro_size_x,
+                micro_size_k,
+            )
+        else:
+            A_shape = (M, K)
+            A_shared_shape = (block_M, (block_K + pad_factor) if apply_pad_a else block_K)
+
         # Define the shapes of matrices and shared memory buffers
-        A_shape = (M, K)
         B_shape = (N // micro_size_y, K // micro_size_k, micro_size_y, micro_size_k)
-        A_shared_shape = (block_M, (block_K + pad_factor) if apply_pad_a else block_K)
         B_shared_shape = (
             block_N // micro_size_y,
             block_K // micro_size_k,
@@ -1089,6 +1147,7 @@ class MatmulINT4WeightPropagationScheduler(MatmulWeightPropagationScheduler):
             warp_row_tiles=warp_row_tiles,
             warp_col_tiles=warp_col_tiles,
             chunk=chunk,
+            transform_kind_a=self.input_transform_kind,
             transform_kind_b=self.weight_transform_kind,
         )
 
@@ -1116,8 +1175,8 @@ class MatmulINT4WeightPropagationScheduler(MatmulWeightPropagationScheduler):
 
                 # Apply memory layout optimizations
                 T.annotate_layout({
-                    A_shared: make_swizzle_layout(A_shared),
-                    # B_shared: make_swizzle_layout(B_shared),
+                    A_shared: make_swizzle_layout(A_shared, is_smooth=is_a_smooth),
+                    B_shared: make_swizzle_layout(B_shared, is_smooth=is_b_smooth),
                 })
 
                 T.use_swizzle(panel_size=10, enable=enable_rasterization)
@@ -1128,9 +1187,16 @@ class MatmulINT4WeightPropagationScheduler(MatmulWeightPropagationScheduler):
                 # Main matrix multiplication pipeline with multiple stages
                 for ko in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
 
-                    # Load A matrix into shared memory
-                    for i, k in T.Parallel(block_M, block_K):
-                        A_shared[i, k] = A[by * block_M + i, ko * block_K + k]
+                    if is_a_smooth:
+                        for i, k, ii, kk in T.Parallel(
+                                block_M // micro_size_x,
+                                block_K // micro_size_k,
+                                micro_size_x,
+                                micro_size_k,
+                        ):
+                            A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x), ko * (block_K // micro_size_k), ii, kk]
+                    else:
+                        T.copy(A[by * block_M, ko * block_K], A_shared)
 
                     # Load B matrix into shared memory
                     for j, k, jj, kk in T.Parallel(
@@ -1398,17 +1464,11 @@ def matmul_macro_tensorcore_weight_propagation_level_ldmatrix(
     block_N = block_col_warps * warp_col_tiles
     block_K = chunk
 
-    # TODO(lei): Can be generalized to analyzed from bank size
-    pad_factor = 8 if in_dtype == "float16" else 16
-
-    can_swizzle_a = block_K * DataType(in_dtype).bits == 512
-    apply_pad_a = not can_swizzle_a
-
     micro_size_x, micro_size_y, micro_size_k = get_mma_micro_size(in_dtype)
 
     A_shape = (M, K)
     B_shape = (N // micro_size_y, K // micro_size_k, micro_size_y, micro_size_k)
-    A_shared_shape = (block_M, (block_K + pad_factor) if apply_pad_a else block_K)
+    A_shared_shape = (block_M, block_K)
     B_shared_shape = (
         block_N // micro_size_y,
         block_K // micro_size_k,

--- a/bitblas/ops/general_matmul/tilelang/dense/matmul_wmma.py
+++ b/bitblas/ops/general_matmul/tilelang/dense/matmul_wmma.py
@@ -31,6 +31,8 @@ class MatmulFineGrainScheduler(MatmulBaseScheduler):
 
     class TLHint(BaseTLHint):
 
+        hint_type: str = "MatmulFineGrainScheduler"
+
         def __init__(self):
             super().__init__()
 

--- a/bitblas/ops/general_matmul/tilelang/dequantize/base.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/base.py
@@ -76,8 +76,6 @@ class MatmulDequantizeBaseParams(BaseScheduler):
         # Validate the matrix transpose settings
         assert (self.trans_A is False), "Currently only support Matrix A not transposed"
         assert (self.trans_B is True), "Currently only support Matrix B transposed"
-        assert (self.input_transform_kind == TransformKind.NonTransform
-               ), "Currently only support NonTransform for input"
 
         # Legalize group_size
         if self.with_scaling and self.group_size == -1:

--- a/bitblas/ops/general_matmul/tilelang/dequantize/gemv_dequantize_simt.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/gemv_dequantize_simt.py
@@ -25,7 +25,7 @@ class GemvDequantizeSIMTScheduler(MatmulDequantizeSIMTBaseScheduler):
     reduce_thread: int = 32
 
     class TLHint(BaseTLHint):
-        
+
         hint_type: str = "GemvDequantizeSIMTScheduler"
 
         def __init__(self):
@@ -62,7 +62,7 @@ class GemvDequantizeSIMTScheduler(MatmulDequantizeSIMTBaseScheduler):
 
     def get_hint_type(self):
         return self.TLHint.hint_type
-    
+
     def serialize_hints_to_configs(self, hints: List[Hint]):
         configs = []
         for hint in hints:

--- a/bitblas/ops/general_matmul/tilelang/dequantize/gemv_dequantize_simt.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/gemv_dequantize_simt.py
@@ -25,6 +25,8 @@ class GemvDequantizeSIMTScheduler(MatmulDequantizeSIMTBaseScheduler):
     reduce_thread: int = 32
 
     class TLHint(BaseTLHint):
+        
+        hint_type: str = "GemvDequantizeSIMTScheduler"
 
         def __init__(self):
             super().__init__()
@@ -58,6 +60,9 @@ class GemvDequantizeSIMTScheduler(MatmulDequantizeSIMTBaseScheduler):
                     f"reduce_thread: {self.reduce_thread}, "
                     "}")
 
+    def get_hint_type(self):
+        return self.TLHint.hint_type
+    
     def serialize_hints_to_configs(self, hints: List[Hint]):
         configs = []
         for hint in hints:

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize.py
@@ -153,7 +153,13 @@ class MatmulDequantizeScheduler(MatmulDequantizeBaseParams):
 
     def detect_scheduler_from_hint(self, hint: BaseTLHint) -> BaseScheduler:
         for scheduler in [
-                self.matmul_dequantize_block_scheduler,
+            self.gemv_dequantize_simt_scheduler,
+            self.matmul_dequantize_simt_scheduler,
+            self.matmul_dequantize_block_scheduler,
+            self.matmul_dequantize_fine_grained_scheduler,
+            self.matmul_dequantize_weight_propagation_scheduler,
+            self.matmul_int4_dequantize_fine_grain_scheduler,
+            self.matmul_int4_dequantize_weight_propagation_scheduler,
         ]:
             if isinstance(hint, scheduler.TLHint):
                 return scheduler

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize.py
@@ -153,13 +153,13 @@ class MatmulDequantizeScheduler(MatmulDequantizeBaseParams):
 
     def detect_scheduler_from_hint(self, hint: BaseTLHint) -> BaseScheduler:
         for scheduler in [
-            self.gemv_dequantize_simt_scheduler,
-            self.matmul_dequantize_simt_scheduler,
-            self.matmul_dequantize_block_scheduler,
-            self.matmul_dequantize_fine_grained_scheduler,
-            self.matmul_dequantize_weight_propagation_scheduler,
-            self.matmul_int4_dequantize_fine_grain_scheduler,
-            self.matmul_int4_dequantize_weight_propagation_scheduler,
+                self.gemv_dequantize_simt_scheduler,
+                self.matmul_dequantize_simt_scheduler,
+                self.matmul_dequantize_block_scheduler,
+                self.matmul_dequantize_fine_grained_scheduler,
+                self.matmul_dequantize_weight_propagation_scheduler,
+                self.matmul_int4_dequantize_fine_grain_scheduler,
+                self.matmul_int4_dequantize_weight_propagation_scheduler,
         ]:
             if isinstance(hint, scheduler.TLHint):
                 return scheduler
@@ -247,6 +247,18 @@ class MatmulDequantizeScheduler(MatmulDequantizeBaseParams):
     def is_dynamic(self) -> bool:
         M, N, K = self.M, self.N, self.K
         return ((not isinstance(M, int)) or (not isinstance(N, int)) or (not isinstance(K, int)))
+
+    def __post_init__(self):
+        # Validate the matrix transpose settings
+        assert (self.trans_A is False), "Currently only support Matrix A not transposed"
+        assert (self.trans_B is True), "Currently only support Matrix B transposed"
+        assert (self.input_transform_kind == TransformKind.NonTransform
+               ), "Currently only support NonTransform for input"
+
+        # Legalize group_size
+        if self.with_scaling and self.group_size == -1:
+            object.__setattr__(self, "group_size", self.K)
+        return
 
 
 __all__ = ["MatmulDequantizeScheduler"]

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize.py
@@ -165,9 +165,8 @@ class MatmulDequantizeScheduler(MatmulDequantizeBaseParams):
                 scheduler_hint_type = scheduler.get_hint_type()
                 if scheduler_hint_type == hint.hint_type:
                     return scheduler
-            except NotImplementedError:
-                raise ValueError(
-                    f"get_hint_type() is not implemented for {type(scheduler)}")
+            except NotImplementedError as e:
+                raise ValueError(f"get_hint_type() is not implemented for {type(scheduler)}") from e
 
         raise ValueError(f"Unsupported hint type: {type(hint)}")
 
@@ -258,8 +257,6 @@ class MatmulDequantizeScheduler(MatmulDequantizeBaseParams):
         # Validate the matrix transpose settings
         assert (self.trans_A is False), "Currently only support Matrix A not transposed"
         assert (self.trans_B is True), "Currently only support Matrix B transposed"
-        assert (self.input_transform_kind == TransformKind.NonTransform
-               ), "Currently only support NonTransform for input"
 
         # Legalize group_size
         if self.with_scaling and self.group_size == -1:

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize.py
@@ -161,8 +161,14 @@ class MatmulDequantizeScheduler(MatmulDequantizeBaseParams):
                 self.matmul_int4_dequantize_fine_grain_scheduler,
                 self.matmul_int4_dequantize_weight_propagation_scheduler,
         ]:
-            if isinstance(hint, scheduler.TLHint):
-                return scheduler
+            try:
+                scheduler_hint_type = scheduler.get_hint_type()
+                if scheduler_hint_type == hint.hint_type:
+                    return scheduler
+            except NotImplementedError:
+                raise ValueError(
+                    f"get_hint_type() is not implemented for {type(scheduler)}")
+
         raise ValueError(f"Unsupported hint type: {type(hint)}")
 
     def with_default_config(self, arch: Optional[TileDevice] = None) -> PrimFunc:

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_simt.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_simt.py
@@ -442,7 +442,7 @@ class MatmulDequantizeSIMTScheduler(MatmulDequantizeSIMTBaseScheduler):
     chunk: int = 16  # Usually determines the K-dimension split size
 
     class TLHint(BaseTLHint):
-        
+
         hint_type = "MatmulDequantizeSIMTScheduler"
 
         def __init__(self):

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_simt.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_simt.py
@@ -442,6 +442,8 @@ class MatmulDequantizeSIMTScheduler(MatmulDequantizeSIMTBaseScheduler):
     chunk: int = 16  # Usually determines the K-dimension split size
 
     class TLHint(BaseTLHint):
+        
+        hint_type = "MatmulDequantizeSIMTScheduler"
 
         def __init__(self):
             super().__init__()
@@ -487,6 +489,9 @@ class MatmulDequantizeSIMTScheduler(MatmulDequantizeSIMTBaseScheduler):
                     f"thread_col_tiles: {self.thread_col_tiles}, "
                     f"chunk: {self.chunk}"
                     "}")
+
+    def get_hint_type(self) -> str:
+        return self.TLHint.hint_type
 
     def serialize_hints_to_configs(self, hints: List[Hint]):
         configs = []

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore.py
@@ -10,8 +10,7 @@ from bitblas.base.roller.rasterization import NoRasterization
 from bitblas.base.utils import get_roller_hints_from_func
 from dataclasses import dataclass
 from bitblas.ops.general_matmul.tirscript import (
-    matmul_dequantize_select_implementation,
-)
+    matmul_dequantize_select_implementation,)
 from bitblas.base.operator_common import QuantizationMemoryStage
 from bitblas.tl.base_hint import BaseTLHint
 from bitblas.quantization import (
@@ -99,23 +98,17 @@ class MatmulDequantizeBaseScheduler(MatmulDequantizeBaseParams):
             return x.astype(in_dtype)
 
         if with_zeros and zeros_mode == "quantized":
-            dequant_func = _tir_packed_to_unsigned_convert_with_zeros(
-                storage_type, storage_nbit
-            )
+            dequant_func = _tir_packed_to_unsigned_convert_with_zeros(storage_type, storage_nbit)
         elif source_format == "uint":
             if num_bits == 8:
                 # 8 num_bits does not need to be compressed
                 dequant_func = naive_cast_dequant
             else:
-                dequant_func = _tir_packed_to_unsigned_convert(
-                    storage_type, storage_nbit
-                )
+                dequant_func = _tir_packed_to_unsigned_convert(storage_type, storage_nbit)
         elif source_format == "int":
             if num_bits == 1:
                 # Dequantize int1 to -1 and 1. Without this step, the values would be 0 and 1, identical to uint1.
-                dequant_func = _tir_packed_int_to_int_convert(
-                    storage_type, storage_nbit
-                )
+                dequant_func = _tir_packed_int_to_int_convert(storage_type, storage_nbit)
             elif num_bits == 8:
                 # 8 num_bits does not need to be compressed
                 dequant_func = naive_cast_dequant
@@ -198,16 +191,15 @@ class MatmulDequantizeBaseScheduler(MatmulDequantizeBaseParams):
                         vi = index // stride_k
                         vj = index % stride_k
                         dequant_qzeros_local[v] = _tir_packed_to_unsigned_convert(
-                            storage_type, storage_nbit
-                        )(
-                            num_bits,
-                            qzeros_buffer[
-                                (k * stride_k + vj) // group_size,
-                                (pid_n * stride_n + vi) // num_elems_per_byte,
-                            ],
-                            (pid_n * stride_n + vi) % num_elems_per_byte,
-                            dtype=storage_dtype,
-                        )
+                            storage_type, storage_nbit)(
+                                num_bits,
+                                qzeros_buffer[
+                                    (k * stride_k + vj) // group_size,
+                                    (pid_n * stride_n + vi) // num_elems_per_byte,
+                                ],
+                                (pid_n * stride_n + vi) % num_elems_per_byte,
+                                dtype=storage_dtype,
+                            )
                 else:
                     raise ValueError(f"Unsupported zeros_mode: {zeros_mode}")
 
@@ -230,19 +222,14 @@ class MatmulDequantizeBaseScheduler(MatmulDequantizeBaseParams):
                             compressed_weight_local[v // num_elems_per_byte],
                             v % num_elems_per_byte,
                             dtype=in_dtype,
-                        )
-                        * scale_local[v // group_size]
-                    )
+                        ) * scale_local[v // group_size])
                 elif zeros_mode == "original":
-                    dequant_weight_local[v] = (
-                        self._decode_func(
-                            num_bits,
-                            compressed_weight_local[v // num_elems_per_byte],
-                            v % num_elems_per_byte,
-                            dtype=in_dtype,
-                        )
-                        - zeros_local[v // group_size]
-                    ) * scale_local[v // group_size]
+                    dequant_weight_local[v] = (self._decode_func(
+                        num_bits,
+                        compressed_weight_local[v // num_elems_per_byte],
+                        v % num_elems_per_byte,
+                        dtype=in_dtype,
+                    ) - zeros_local[v // group_size]) * scale_local[v // group_size]
                 elif zeros_mode == "rescale":
                     dequant_weight_local[v] = (
                         self._decode_func(
@@ -250,20 +237,15 @@ class MatmulDequantizeBaseScheduler(MatmulDequantizeBaseParams):
                             compressed_weight_local[v // num_elems_per_byte],
                             v % num_elems_per_byte,
                             dtype=in_dtype,
-                        )
-                        * scale_local[v // group_size]
-                        - zeros_local[v // group_size]
-                    )
+                        ) * scale_local[v // group_size] - zeros_local[v // group_size])
                 elif zeros_mode == "quantized":
-                    dequant_weight_local[v] = (
-                        self._decode_func(
-                            num_bits,
-                            compressed_weight_local[v // num_elems_per_byte],
-                            v % num_elems_per_byte,
-                            zero=dequant_qzeros_local[v // group_size],
-                            dtype=in_dtype,
-                        )
-                    ) * scale_local[v // group_size]
+                    dequant_weight_local[v] = (self._decode_func(
+                        num_bits,
+                        compressed_weight_local[v // num_elems_per_byte],
+                        v % num_elems_per_byte,
+                        zero=dequant_qzeros_local[v // group_size],
+                        dtype=in_dtype,
+                    )) * scale_local[v // group_size]
                 else:
                     raise ValueError(f"Unsupported zeros_mode: {zeros_mode}")
 
@@ -343,16 +325,15 @@ class MatmulDequantizeBaseScheduler(MatmulDequantizeBaseParams):
                         vi = index // stride_k
                         vj = index % stride_k
                         dequant_qzeros_local[v] = _tir_packed_to_unsigned_convert(
-                            storage_type, storage_nbit
-                        )(
-                            num_bits,
-                            qzeros_buffer[
-                                (k * stride_k + vj) // group_size,
-                                (pid_n * stride_n + vi) // num_elems_per_byte,
-                            ],
-                            (pid_n * stride_n + vi) % num_elems_per_byte,
-                            dtype=storage_dtype,
-                        )
+                            storage_type, storage_nbit)(
+                                num_bits,
+                                qzeros_buffer[
+                                    (k * stride_k + vj) // group_size,
+                                    (pid_n * stride_n + vi) // num_elems_per_byte,
+                                ],
+                                (pid_n * stride_n + vi) % num_elems_per_byte,
+                                dtype=storage_dtype,
+                            )
                 else:
                     raise ValueError(f"Unsupported zeros_mode: {zeros_mode}")
 
@@ -440,24 +421,10 @@ class MatmulDequantizeBaseScheduler(MatmulDequantizeBaseParams):
                 threads,
             )
         else:
-            return self._normal_dequant(
-                compressed_weight_local,
-                scale_local,
-                zeros_local,
-                dequant_qzeros_local,
-                dequant_weight_local,
-                scale_buffer,
-                zeros_buffer,
-                qzeros_buffer,
-                local_size,
-                pid_n,
-                tx,
-                k,
-                i,
-                stride_n,
-                stride_k,
-                threads
-            )
+            return self._normal_dequant(compressed_weight_local, scale_local, zeros_local,
+                                        dequant_qzeros_local, dequant_weight_local, scale_buffer,
+                                        zeros_buffer, qzeros_buffer, local_size, pid_n, tx, k, i,
+                                        stride_n, stride_k, threads)
 
     @property
     def num_elems_per_byte(self):
@@ -522,16 +489,14 @@ class MatmulDequantizeBlockScheduler(MatmulDequantizeBaseScheduler):
             }
 
         def __repr__(self):
-            return (
-                "{"
-                f"block_M={self.block_M},"
-                f"block_N={self.block_N},"
-                f"block_K={self.block_K},"
-                f"num_stages={self.num_stages},"
-                f"threads={self.threads},"
-                f"enable_rasterization={self.enable_rasterization}"
-                "}"
-            )
+            return ("{"
+                    f"block_M={self.block_M},"
+                    f"block_N={self.block_N},"
+                    f"block_K={self.block_K},"
+                    f"num_stages={self.num_stages},"
+                    f"threads={self.threads},"
+                    f"enable_rasterization={self.enable_rasterization}"
+                    "}")
 
     def get_hint_type(self) -> str:
         return self.TLHint.hint_type
@@ -578,9 +543,7 @@ class MatmulDequantizeBlockScheduler(MatmulDequantizeBaseScheduler):
 
         M = self.maybe_dynamic(self.M, "m")
         N, K = self.N, self.K
-        assert isinstance(N, int) and isinstance(
-            K, int
-        ), "Do not support dynamic N and K Currently"
+        assert isinstance(N, int) and isinstance(K, int), "Do not support dynamic N and K Currently"
 
         trans_A, trans_B = self.trans_A, self.trans_B
 
@@ -652,18 +615,17 @@ class MatmulDequantizeBlockScheduler(MatmulDequantizeBaseScheduler):
 
         @T.prim_func
         def general_shared_dequant_matmul(
-            A: T.Buffer(A_shape, in_dtype),
-            B: T.Buffer(B_shape, storage_dtype),
-            LUT: T.Buffer(LUT_shape, in_dtype),
-            Scale: T.Buffer(Scale_shape, in_dtype),
-            Qzeros: T.Buffer(Qzeros_shape, storage_dtype),
-            Zeros: T.Buffer(Zeros_shape, in_dtype),
-            C: T.Buffer(C_shape, out_dtype),
-            Bias: T.Buffer(Bias_shape, in_dtype),
+                A: T.Buffer(A_shape, in_dtype),
+                B: T.Buffer(B_shape, storage_dtype),
+                LUT: T.Buffer(LUT_shape, in_dtype),
+                Scale: T.Buffer(Scale_shape, in_dtype),
+                Qzeros: T.Buffer(Qzeros_shape, storage_dtype),
+                Zeros: T.Buffer(Zeros_shape, in_dtype),
+                C: T.Buffer(C_shape, out_dtype),
+                Bias: T.Buffer(Bias_shape, in_dtype),
         ):
             with T.Kernel(
-                T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads
-            ) as (bx, by):
+                    T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
                 A_shared = T.alloc_shared(A_shared_shape, in_dtype)
                 B_shared = T.alloc_shared(B_shared_shape, storage_dtype)
                 B_local = T.alloc_local([local_size_compressed], storage_dtype)
@@ -671,9 +633,7 @@ class MatmulDequantizeBlockScheduler(MatmulDequantizeBaseScheduler):
                 zeros_local = T.alloc_local([local_zeros_size], in_dtype)
                 dequant_qzeros_local = T.alloc_local([local_qzeros_size], storage_dtype)
                 B_dequantize_local = T.alloc_local([local_size], in_dtype)
-                B_dequantize_shared = T.alloc_shared(
-                    B_dequantize_shared_shape, in_dtype
-                )
+                B_dequantize_shared = T.alloc_shared(B_dequantize_shared_shape, in_dtype)
                 C_shared = T.alloc_shared([block_M, block_N], out_dtype)
                 C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
 
@@ -689,18 +649,12 @@ class MatmulDequantizeBlockScheduler(MatmulDequantizeBaseScheduler):
                     T.copy(A[by * block_M, ko * block_K], A_shared)
                     T.copy(B[bx * block_N, ko * block_K // num_elems_per_byte], B_shared)
 
-                    for i in T.serial(
-                        block_N
-                        * block_K
-                        // num_elems_per_byte
-                        // (threads * local_size_compressed)
-                    ):
+                    for i in T.serial(block_N * block_K // num_elems_per_byte //
+                                      (threads * local_size_compressed)):
                         for v in T.vectorized(0, local_size_compressed):
                             index = (
-                                i * threads * local_size_compressed
-                                + tx * local_size_compressed
-                                + v
-                            )
+                                i * threads * local_size_compressed + tx * local_size_compressed +
+                                v)
                             vi = index // (block_K // num_elems_per_byte)
                             vj = index % (block_K // num_elems_per_byte)
                             B_local[v] = B_shared[vi, vj]

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore.py
@@ -478,6 +478,7 @@ class MatmulDequantizeBlockScheduler(MatmulDequantizeBaseScheduler):
     enable_rasterization: bool = False  # Enhance L2 Locality
 
     class TLHint(BaseTLHint):
+        hint_type: str = "MatmulDequantizeBlockScheduler"
 
         def __init__(self):
             super().__init__()
@@ -531,6 +532,9 @@ class MatmulDequantizeBlockScheduler(MatmulDequantizeBaseScheduler):
                 f"enable_rasterization={self.enable_rasterization}"
                 "}"
             )
+
+    def get_hint_type(self) -> str:
+        return self.TLHint.hint_type
 
     def serialize_hints_to_configs(self, hints: List[Hint]):
         configs = []

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore_finegrained.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore_finegrained.py
@@ -21,14 +21,6 @@ from bitblas.ops.general_matmul.tilelang.dequantize.matmul_dequantize_tensorcore
     MatmulDequantizeBaseScheduler,  # noqa: F401
 )
 from bitblas.tl.base_hint import BaseTLHint
-from bitblas.quantization import (
-    _tir_packed_int_to_int_convert,
-    _tir_packed_to_signed_convert,
-    _tir_packed_to_unsigned_convert,
-    _tir_packed_to_fp4_to_f16,
-    _tir_u8_to_f8_e4m3_to_f16,
-    _tir_packed_to_unsigned_convert_with_zeros,
-)
 
 # GPU warp configuration for NVIDIA GPUs
 warp_size = 32
@@ -49,7 +41,7 @@ class MatmulDequantizeFineGrainedScheduler(MatmulDequantizeBaseScheduler):
     enable_rasterization: bool = False  # Enhance L2 Locality
 
     class TLHint(BaseTLHint):
-        
+
         hint_type: str = "MatmulDequantizeFineGrainedScheduler"
 
         def __init__(self):

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore_finegrained.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore_finegrained.py
@@ -49,6 +49,8 @@ class MatmulDequantizeFineGrainedScheduler(MatmulDequantizeBaseScheduler):
     enable_rasterization: bool = False  # Enhance L2 Locality
 
     class TLHint(BaseTLHint):
+        
+        hint_type: str = "MatmulDequantizeFineGrainedScheduler"
 
         def __init__(self):
             super().__init__()
@@ -107,6 +109,9 @@ class MatmulDequantizeFineGrainedScheduler(MatmulDequantizeBaseScheduler):
                     f"num_stages={self.num_stages},"
                     f"enable_rasterization={self.enable_rasterization}"
                     "}")
+
+    def get_hint_type(self) -> str:
+        return self.TLHint.hint_type
 
     def serialize_hints_to_configs(self, hints: List[Hint]):
         configs = []
@@ -404,7 +409,7 @@ class MatmulDequantizeFineGrainedScheduler(MatmulDequantizeBaseScheduler):
 class MatmulINT4DequantizeFineGrainedScheduler(MatmulDequantizeFineGrainedScheduler):
 
     class TLHint(MatmulDequantizeFineGrainedScheduler.TLHint):
-        pass
+        hint_type: str = "MatmulINT4DequantizeFineGrainedScheduler"
 
     def get_roller_configs(self, arch: TileDevice = None, topk: int = 10):
         layout = f"{'t' if self.trans_A else 'n'}{'t' if self.trans_B else 'n'}"

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore_finegrained.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore_finegrained.py
@@ -403,6 +403,9 @@ class MatmulDequantizeFineGrainedScheduler(MatmulDequantizeBaseScheduler):
 @dataclass
 class MatmulINT4DequantizeFineGrainedScheduler(MatmulDequantizeFineGrainedScheduler):
 
+    class TLHint(MatmulDequantizeFineGrainedScheduler.TLHint):
+        pass
+
     def get_roller_configs(self, arch: TileDevice = None, topk: int = 10):
         layout = f"{'t' if self.trans_A else 'n'}{'t' if self.trans_B else 'n'}"
         M = self.M

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore_weight_transform.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore_weight_transform.py
@@ -238,7 +238,8 @@ class MatmulDequantizeWeightPropagationScheduler(MatmulDequantizeFineGrainedSche
                                 micro_size_x,
                                 micro_size_k,
                         ):
-                            A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x), ko * (block_K // micro_size_k), ii, kk]
+                            A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x),
+                                                       ko * (block_K // micro_size_k), ii, kk]
                     else:
                         T.copy(A[by * block_M, ko * block_K], A_shared)
 
@@ -877,7 +878,8 @@ class MatmulINT4DequantizeWeightPropagationScheduler(MatmulDequantizeWeightPropa
                                 micro_size_x,
                                 micro_size_k,
                         ):
-                            A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x), ko * (block_K // micro_size_k), ii, kk]
+                            A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x),
+                                                       ko * (block_K // micro_size_k), ii, kk]
                     else:
                         T.copy(A[by * block_M, ko * block_K], A_shared)
 

--- a/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore_weight_transform.py
+++ b/bitblas/ops/general_matmul/tilelang/dequantize/matmul_dequantize_tensorcore_weight_transform.py
@@ -39,7 +39,7 @@ class MatmulDequantizeWeightPropagationScheduler(MatmulDequantizeFineGrainedSche
     weight_transform_kind: TransformKind = TransformKind.LDMatrixTransform
 
     class TLHint(MatmulDequantizeFineGrainedScheduler.TLHint):
-        pass
+        hint_type: str = "MatmulDequantizeWeightPropagationScheduler"
 
     def apply_config(
         self,
@@ -629,7 +629,7 @@ class MatmulDequantizeWeightPropagationScheduler(MatmulDequantizeFineGrainedSche
 class MatmulINT4DequantizeWeightPropagationScheduler(MatmulDequantizeWeightPropagationScheduler):
 
     class TLHint(MatmulDequantizeWeightPropagationScheduler.TLHint):
-        pass
+        hint_type: str = "MatmulINT4DequantizeWeightPropagationScheduler"
 
     def get_roller_configs(self, arch: TileDevice = None, topk: int = 10):
         layout = f"{'t' if self.trans_A else 'n'}{'t' if self.trans_B else 'n'}"

--- a/bitblas/ops/operator.py
+++ b/bitblas/ops/operator.py
@@ -383,7 +383,7 @@ class Operator(object):
     def get_profile_tensors(self, dynamic_symbolic_constraints: Optional[Dict] = None):
         if dynamic_symbolic_constraints is None:
             dynamic_symbolic_constraints = {}
-        func = retrieve_func_from_module(self.scheduled_ir_module)
+        func = self.prim_func or retrieve_func_from_module(self.scheduled_ir_module)
         device = self.arch.device
 
         def var_warpper(v):

--- a/bitblas/ops/operator.py
+++ b/bitblas/ops/operator.py
@@ -383,7 +383,7 @@ class Operator(object):
     def get_profile_tensors(self, dynamic_symbolic_constraints: Optional[Dict] = None):
         if dynamic_symbolic_constraints is None:
             dynamic_symbolic_constraints = {}
-        func = self.prim_func
+        func = retrieve_func_from_module(self.scheduled_ir_module)
         device = self.arch.device
 
         def var_warpper(v):

--- a/bitblas/relax/transform/apply_fast_tuning.py
+++ b/bitblas/relax/transform/apply_fast_tuning.py
@@ -136,11 +136,13 @@ class ApplyFastTuning:  # pylint: disable=too-few-public-methods
                         trace.apply_to_schedule(sch, remove_postproc=False)
                         updated_functions[g_var] = sch.mod["main"].with_attr("tir.is_scheduled", 1)
                         continue
+                
+                specalized_function = func.with_attr("global_symbol", g_var.name_hint)
 
-                if check_func_with_dynamic(func):
+                if check_func_with_dynamic(specalized_function):
 
                     dispatch_mod = fast_tune_with_dynamic_range(
-                        func,
+                        specalized_function,
                         target=target,
                         topk=self.topk,
                         parallel_build=self.parallel_build,
@@ -161,7 +163,7 @@ class ApplyFastTuning:  # pylint: disable=too-few-public-methods
                 else:
                     # otherwise is static shape analysis
                     _, best = fast_tune(
-                        func,
+                        specalized_function,
                         target=target,
                         topk=self.topk,
                         parallel_build=self.parallel_build,

--- a/bitblas/relax/transform/apply_fast_tuning.py
+++ b/bitblas/relax/transform/apply_fast_tuning.py
@@ -136,7 +136,7 @@ class ApplyFastTuning:  # pylint: disable=too-few-public-methods
                         trace.apply_to_schedule(sch, remove_postproc=False)
                         updated_functions[g_var] = sch.mod["main"].with_attr("tir.is_scheduled", 1)
                         continue
-                
+
                 specalized_function = func.with_attr("global_symbol", g_var.name_hint)
 
                 if check_func_with_dynamic(specalized_function):

--- a/bitblas/tl/base_hint.py
+++ b/bitblas/tl/base_hint.py
@@ -8,6 +8,9 @@ from typing import Dict
 # Base class for Tensor Layout Hints that defines the interface and common functionality for derived classes.
 class BaseTLHint(ABC):
 
+    # hint identifier
+    hint_type: str = "base"
+
     # Constructor for the BaseTLHint class, takes variable arguments (*args and **kwargs) to allow flexibility.
     def __init__(self, *args, **kwargs):
         # Calls the superclass constructor (useful in complex inheritance hierarchies).

--- a/bitblas/tl/mma_layout.py
+++ b/bitblas/tl/mma_layout.py
@@ -30,6 +30,18 @@ def ldmatrix_16x32_to_shared_16x32_layout_b(thread_id, local_id):
     return row, col
 
 
+def ldmatrix_32x16_to_shared_16x32_layout_a(thread_id, local_id):
+    row = thread_id % 16
+    col = local_id + (thread_id // 16) * 16
+    return row, col
+
+
+def ldmatrix_32x16_to_shared_16x32_layout_b(thread_id, local_id):
+    row = (thread_id // 16) * 8 + (thread_id % 8)
+    col = local_id + 16 * ((thread_id % 16) // 8)
+    return row, col
+
+
 def mma_store_32x8_to_shared_16x16_layout(thread_id, local_id):
     row = 8 * (local_id % 4 // 2) + (thread_id // 4)
     col = 8 * (local_id // 4) + (thread_id % 4) * 2 + (local_id % 2)

--- a/bitblas/tl/tuner.py
+++ b/bitblas/tl/tuner.py
@@ -72,7 +72,7 @@ def apply_and_build_parallel(scheduler,
                              arch,
                              num_repeats=3,
                              max_workers=10,
-                             timeout=30,
+                             timeout=60,
                              data_distribution="uniform") -> CompileResult:
     cpresults = []
 

--- a/testing/python/operators/test_general_matmul_tile_schedule.py
+++ b/testing/python/operators/test_general_matmul_tile_schedule.py
@@ -11,7 +11,6 @@ import logging
 from bitblas import set_log_level
 import numpy as np
 
-print("bitblas. path is ", bitblas.__path__)
 np.random.seed(0)
 
 set_log_level(logging.DEBUG)

--- a/testing/python/tilelang/test_tilelang_mma_macro_gemm.py
+++ b/testing/python/tilelang/test_tilelang_mma_macro_gemm.py
@@ -885,6 +885,208 @@ def assert_tl_matmul_with_ladder_weight_only_transform_block_reduce_int4_correct
     torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
 
+@simplify_prim_func
+def tl_matmul_with_ladder_input_weight_transform(
+    M,
+    N,
+    K,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    transform_a,
+    transform_b,
+):
+    assert in_dtype in [
+        "float16",
+        "int8",
+    ], "Currently only float16 and int8 are supported"
+    assert out_dtype in [
+        "float16",
+        "float32",
+        "int32",
+    ], "Currently only float16, float32 and int32 are supported"
+    assert transform_a > 0, "transform_a should be greater than 0"
+    micro_size_x = micro_size_y = micro_size_k = 16
+
+    if out_dtype == "int32":
+        micro_size_k = 32
+
+    # This is a debug config
+    block_row_warps = 2
+    block_col_warps = 2
+
+    warp_rows = 1
+    warp_cols = 1
+    warp_row_tiles = micro_size_x * warp_rows
+    warp_col_tiles = micro_size_y * warp_cols
+
+    chunk = 32 if in_dtype == "float16" else 64
+    shared_scope = "shared"
+
+    # Pipeline Stage
+    stage = 2
+
+    block_M = block_row_warps * warp_row_tiles
+    block_N = block_col_warps * warp_col_tiles
+    block_K = chunk
+
+    A_shape = (M // micro_size_x, K // micro_size_k, micro_size_x, micro_size_k)
+    B_shape = (N // micro_size_y, K // micro_size_k, micro_size_y, micro_size_k)
+    A_shared_shape = (block_M // micro_size_x, block_K // micro_size_k, micro_size_x, micro_size_k)
+    B_shared_shape = (block_N // micro_size_y, block_K // micro_size_k, micro_size_y, micro_size_k)
+    C_shared_shape = (
+        block_M // micro_size_x,
+        block_N // micro_size_y,
+        micro_size_x,
+        micro_size_y,
+    )
+
+    warp_size = 32
+    threads = warp_size * (block_row_warps * block_col_warps)
+    local_size_a = (micro_size_x * micro_size_k) // warp_size
+    local_size_b = (micro_size_y * micro_size_k) // warp_size
+    local_size_c = (micro_size_x * micro_size_y) // warp_size
+    warp_rows = warp_row_tiles // micro_size_x
+    warp_cols = warp_col_tiles // micro_size_y
+
+    # MMA Wrapper to Auto Generate Code for MMA
+    mma_emitter = TensorCoreIntrinEmitterWithLadderTransform(
+        a_dtype=in_dtype,
+        b_dtype=in_dtype,
+        accum_dtype=accum_dtype,
+        a_transposed=False,
+        b_transposed=True,
+        block_row_warps=block_row_warps,
+        block_col_warps=block_col_warps,
+        warp_row_tiles=warp_row_tiles,
+        warp_col_tiles=warp_col_tiles,
+        chunk=chunk,
+        transform_kind_a=transform_a,
+        transform_kind_b=transform_b)
+
+    @T.prim_func
+    def main(
+            A: T.Buffer(A_shape, in_dtype),
+            B: T.Buffer(B_shape, in_dtype),
+            C: T.Buffer((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype, scope=shared_scope)
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype, scope=shared_scope)
+            C_shared = T.alloc_shared(C_shared_shape, out_dtype, scope=shared_scope)
+            A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
+            B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
+            C_local = T.alloc_local((warp_rows * warp_cols * local_size_c), accum_dtype)
+            thread_bindings = T.thread_binding(0, threads, "threadIdx.x")
+
+            T.use_swizzle(panel_size=10)
+
+            T.clear(C_local)
+
+            for ko in T.Pipelined((K // block_K), num_stages=stage):
+                # Load A into shared memory
+                for i, k, ii, kk in T.Parallel(block_M // micro_size_x, block_K // micro_size_k,
+                                               micro_size_x, micro_size_k):
+                    A_shared[i, k, ii, kk] = A[by * (block_M // micro_size_x) + i,
+                                               ko * (block_K // micro_size_k) + k, ii, kk]
+
+                # Load B into shared memory
+                for j, k, jj, kk in T.Parallel(block_N // micro_size_y, block_K // micro_size_k,
+                                               micro_size_y, micro_size_k):
+                    B_shared[j, k, jj, kk] = B[bx * (block_N // micro_size_y) + j,
+                                               ko * (block_K // micro_size_k) + k, jj, kk]
+
+                for ki in T.serial(0, (block_K // micro_size_k)):
+
+                    mma_emitter.ldmatrix_a(
+                        A_local,
+                        A_shared,
+                        ki,
+                        thread_bindings=thread_bindings,
+                    )
+
+                    mma_emitter.ldmatrix_b(
+                        B_local,
+                        B_shared,
+                        ki,
+                        thread_bindings=thread_bindings,
+                    )
+
+                    mma_emitter.mma(A_local, B_local, C_local)
+
+            mma_emitter.stmatrix(
+                C_local,
+                C_shared,
+                thread_bindings=thread_bindings,
+            )
+
+            for i, j in T.Parallel(block_M, block_N):
+                C[by * block_M + i,
+                  bx * block_N + j] = C_shared[i // micro_size_x, j // micro_size_y,
+                                               i % micro_size_x, j % micro_size_y]
+
+    return main
+
+
+def assert_tl_matmul_with_ladder_input_weight_transform_correctness(M, N, K, in_dtype, out_dtype,
+                                                                    accum_dtype, transform_a,
+                                                                    transform_b):
+    matmul = tl_matmul_with_ladder_input_weight_transform(M, N, K, in_dtype, out_dtype, accum_dtype,
+                                                          transform_a, transform_b)
+
+    mod, params = TL.lower(matmul)
+    src_code = mod.imported_modules[0].get_source()
+    # src_code is the generated cuda source
+    assert src_code is not None
+
+    A = torch.rand(M, K, device="cuda", dtype=getattr(torch, in_dtype))
+    B = torch.rand(N, K, device="cuda", dtype=getattr(torch, in_dtype))
+    C = torch.zeros(M, N, device="cuda", dtype=getattr(torch, accum_dtype))
+
+    ladder_permutate_config_A = bitblas.ops.LadderPermutateConfig(
+        M=M,
+        N=K,
+        datatype=in_dtype,
+        storage_dtype=in_dtype,
+        propagate_kind="A",
+        transpose_matrix=False,
+        transform_kind=transform_a,
+    )
+
+    ladder_permutate_a = bitblas.ops.LadderPermutate(ladder_permutate_config_A)
+
+    ladder_permutate_config_B = bitblas.ops.LadderPermutateConfig(
+        M=N,
+        N=K,
+        datatype=in_dtype,
+        storage_dtype=in_dtype,
+        propagate_kind="B",
+        transform_kind=transform_b,
+        transpose_matrix=True,
+    )
+
+    ladder_permutate_b = bitblas.ops.LadderPermutate(ladder_permutate_config_B)
+
+    mod = TL.Profiler(mod, params, [], TL.TensorSupplyType.Integer)
+
+    LA = ladder_permutate_a(A.cpu()).cuda()
+    LB = ladder_permutate_b(B.cpu()).cuda()
+
+    mod(LA, LB, C)
+
+    latency = mod.do_bench(mod.func, warmup=25)
+
+    # Ensure that the latency is not None
+    assert latency is not None
+
+    # Get Reference Result
+    ref_c = torch.matmul(A, B.T).to(getattr(torch, accum_dtype))
+    # print("Ref C: ", ref_c)
+    # print("C: ", C)
+    torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
+
+
 def test_assert_tl_matmul():
     assert_tl_matmul_correctness(128, 128, 128, "float16", "float16", "float16")
     assert_tl_matmul_correctness(128, 256, 256, "float16", "float32", "float32")
@@ -906,6 +1108,11 @@ def test_assert_assert_tl_matmul_with_ladder_weight_only_transform():
 def test_assert_tl_matmul_with_ladder_weight_only_transform_block_reduce_int4():
     assert_tl_matmul_with_ladder_weight_only_transform_block_reduce_int4_correctness(
         256, 1024, 512, "float16", "float16", "float16", 3)
+
+
+def test_assert_tl_matmul_with_ladder_input_weight_transform():
+    assert_tl_matmul_with_ladder_input_weight_transform_correctness(256, 256, 256, "float16",
+                                                                    "float16", "float16", 2, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request mainly shift tvm intrin related import into lazy import format to save the module import time when we write `import bitblas` in python.

Before this modification be applied:

```bash
import time:  39164.91985321045 ms
config time:  6095.165014266968 ms
hardware_aware_finetune time:  33147.03679084778 ms
```

After this modification be applied:

```bash
import time:  2109.856128692627 ms
config time:  22495.219230651855 ms
hardware_aware_finetune time:  49844.87271308899 ms
```

Test script to reproduce the results:

```python
import time
import_start_time = time.time()
import bitblas
import_end_time = time.time()

print("bitblas.path: ", bitblas.__path__)

from bitblas import tvm as tvm


M = N = K = 256
A_dtype = "float16"
W_dtype = "float16"
accum_dtype = "float16"
out_dtype = "float16"

bitblas.set_log_level("DEBUG")

config_create_time = time.time()
matmul_config = bitblas.MatmulConfig(
    M=M,  # M dimension
    N=N,  # N dimension
    K=K,  # K dimension
    A_dtype=A_dtype,  # activation A dtype
    W_dtype=W_dtype,  # weight W dtype
    accum_dtype=accum_dtype,  # accumulation dtype
    out_dtype=out_dtype,  # output dtype
    layout="nt",  # matrix layout, "nt" indicates the layout of A is non-transpose and the layout of W is transpose
    propagate_b=False,  # propagate B matrix
)

matmul = bitblas.Matmul(config=matmul_config, enable_tuning=False, backend="tl")
config_end_time = time.time()

hardware_aware_finetune_start_time = time.time()
matmul.hardware_aware_finetune()
hardware_aware_finetune_end_time = time.time()

print("import time: ", (import_end_time - import_start_time) * 1000, "ms")
print("config time: ", (config_end_time - config_create_time) * 1000, "ms")
print("hardware_aware_finetune time: ", (hardware_aware_finetune_end_time - hardware_aware_finetune_start_time) * 1000, "ms")

```