### PR TITLE
[Bugfix] Fix correctness issue for float16xuint1 with fast dequantize

### DIFF
--- a/bitblas/__init__.py
+++ b/bitblas/__init__.py
@@ -153,4 +153,4 @@ from .ops.general_matmul_splitk import MatmulConfigWithSplitK, MatmulWithSplitK 
 from .ops.general_flashatten import FlashAttenConfig, FlashAtten  # noqa: F401
 from .module import Linear  # noqa: F401
 
-__version__ = "0.1.0"
+from .version import __version__  # noqa: F401

--- a/bitblas/gpu/intrin/lop3.py
+++ b/bitblas/gpu/intrin/lop3.py
@@ -685,15 +685,29 @@ __device__ void decode_i2u_to_f16_scale_zeros_quantized(T1 *_i2u, T2 *B_local_de
 """
 
 decode_i1_to_f16 = """
-template <typename T1, typename T2>
-__device__ void decode_i1u_to_f16(T1 *_i1s, T2 *B_local_decode, const int N = 8)
+/*
+Kind 0: original
+Kind 1: rescale
+Kind 2: quantized
+# documents for zeros_mode:
+# original: target = (dequantize_weight - zero_point) * scale
+# rescale: target = dequantize_weight * scale - zero_point
+# quantized: target = (dequantize_weight - dequantize_zeros) * scale
+# Notice: only support "original" and "rescale" now
+zeros_mode: Literal["original", "rescale", "quantized"] = "original"
+*/
+template <typename T1, typename T2, bool isSigned = false, bool withScaling = false, bool withZeros = false, int ZerosKind = 1>
+__device__ void decode_i1b_to_f16(T1 *_i1s, T2 *B_local_decode, const int N = 8, half *scale = nullptr, half *zeros = nullptr)
 {
     uint *h = reinterpret_cast<uint *>(B_local_decode);
 
     static constexpr uint immLut = (0xf0 & 0xcc) | 0xaa;
     static constexpr uint BOTTOM_MASK = 0x00010001;
     static constexpr uint FP16_TOP_MAGIC_NUM = 0x64006400;
-    static constexpr uint MEDIAN_NUM = 0x64006400;
+    static constexpr uint MEDIAN_NUM = isSigned ? 0x64006400 : 0x64006400;
+    static constexpr uint TRANSFORM_SUBTRACT = 0xbc00bc00; // for signed int 2x - 1
+    // interleave {e31,e29,e27,e25,e23,e21,e19,e17,e15,e13,e11,e9,e7,e5,e3,e1,e30,e28,e26,e24,e22,e20,e18,e16,e14,e12,e10,e8,e6,e4,e2,e0}
+    // only decode e7,e5,e3,e1,e8,e6,e4,e2,e0
     int8_t const i1s_i16 = *reinterpret_cast<int8_t *>(_i1s);
     int i1s = (i1s_i16 & 0x0f);
     i1s |= ((i1s_i16 & 0xf0) << 12);
@@ -701,38 +715,41 @@ __device__ void decode_i1u_to_f16(T1 *_i1s, T2 *B_local_decode, const int N = 8)
     // decode 2 elems at one time.
     for (int i = 0; i < (N / 2); i++)
     {
+
         asm volatile("lop3.b32 %0, %1, %2, %3, %4;\\n"
                      : "=r"(h[i])
                      : "r"(i1s >> (1 * i)), "n"(BOTTOM_MASK), "n"(FP16_TOP_MAGIC_NUM), "n"(immLut));
         asm volatile("sub.f16x2 %0, %1, %2;\\n" : "=r"(h[i]) : "r"(h[i]), "r"(MEDIAN_NUM));
+        if constexpr (isSigned)
+        {
+            asm volatile("add.f16x2 %0, %1, %2;\\n" : "=r"(h[i]) : "r"(h[i]), "r"(h[i]));
+            asm volatile("add.f16x2 %0, %1, %2;\\n" : "=r"(h[i]) : "r"(h[i]), "r"(TRANSFORM_SUBTRACT));
+        }
+        if constexpr (withZeros && ZerosKind == 0)
+        {
+            asm volatile("sub.f16x2 %0, %1, %2;\\n" : "=r"(h[i]) : "r"(h[i]), "r"(__pack_half2(*zeros, *zeros)));
+        }
+        if constexpr (withScaling)
+        {
+            asm volatile("fma.rn.f16x2 %0, %1, %2, %3;\\n" : "=r"(h[i]) : "r"(h[i]), "r"(__pack_half2(*scale, *scale)), "r"(0));
+        }
+        if constexpr (withZeros && ZerosKind == 1)
+        {
+            asm volatile("sub.f16x2 %0, %1, %2;\\n" : "=r"(h[i]) : "r"(h[i]), "r"(__pack_half2(*zeros, *zeros)));
+        }
     }
 }
 
 template <typename T1, typename T2>
 __device__ void decode_i1s_to_f16(T1 *_i1s, T2 *B_local_decode, const int N = 8)
 {
-    uint *h = reinterpret_cast<uint *>(B_local_decode);
+    decode_i1b_to_f16<T1, T2, true>(_i1s, B_local_decode, N);
+}
 
-    static constexpr uint immLut = (0xf0 & 0xcc) | 0xaa;
-    static constexpr uint BOTTOM_MASK = 0x00010001;
-    static constexpr uint FP16_TOP_MAGIC_NUM = 0x64006400;
-    static constexpr uint MEDIAN_NUM = 0x64006400;
-    static constexpr uint TRANSFORM_SUBTRACT = 0xbc00bc00; // for signed int 2x - 1
-
-    int8_t const i1s_i16 = *reinterpret_cast<int8_t *>(_i1s);
-    int i1s = (i1s_i16 & 0x0f);
-    i1s |= ((i1s_i16 & 0xf0) << 12);
-#pragma unroll
-    // decode 2 elems at one time.
-    for (int i = 0; i < (N / 2); i++)
-    {
-        asm volatile("lop3.b32 %0, %1, %2, %3, %4;\\n"
-                     : "=r"(h[i])
-                     : "r"(i1s >> (1 * i)), "n"(BOTTOM_MASK), "n"(FP16_TOP_MAGIC_NUM), "n"(immLut));
-        asm volatile("sub.f16x2 %0, %1, %2;\\n" : "=r"(h[i]) : "r"(h[i]), "r"(MEDIAN_NUM));
-        asm volatile("add.f16x2 %0, %1, %2;\\n" : "=r"(h[i]) : "r"(h[i]), "r"(h[i]));
-        asm volatile("add.f16x2 %0, %1, %2;\\n" : "=r"(h[i]) : "r"(h[i]), "r"(TRANSFORM_SUBTRACT));
-    }
+template <typename T1, typename T2>
+__device__ void decode_i1u_to_f16(T1 *_i1u, T2 *B_local_decode, const int N = 8)
+{
+    decode_i1b_to_f16<T1, T2, false>(_i1u, B_local_decode, N);
 }
 """
 

--- a/bitblas/ops/lop3_permutate/lop3_permutate_impl.py
+++ b/bitblas/ops/lop3_permutate/lop3_permutate_impl.py
@@ -80,7 +80,7 @@ def tir_interleave_weight(
                 B_tmp_4[v0, v1] = ((B[v0, v1] & T.uint32(0x0000F000)) >> 12) << 24
                 B_tmp_5[v0, v1] = ((B[v0, v1] & T.uint32(0x000F0000)) >> 16) << 8
                 B_tmp_6[v0, v1] = ((B[v0, v1] & T.uint32(0x00F00000)) >> 20) << 12
-                B_tmp_7[v0, v1] = ((B[v0, v1] & T.uint32(0x00F00000)) >> 24) << 20
+                B_tmp_7[v0, v1] = ((B[v0, v1] & T.uint32(0x0F000000)) >> 24) << 20
                 B[v0, v1] = (
                     B_tmp_1[v0, v1]
                     | B_tmp_2[v0, v1]

--- a/bitblas/version.py
+++ b/bitblas/version.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import os
+
+# Get the absolute path of the current Python script's directory
+current_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Get the absolute path of the project root directory (one level above the current directory)
+project_root_dir = os.path.abspath(os.path.join(current_dir, ".."))
+
+# Define the path to the VERSION file located in the project root directory
+version_file_path = os.path.join(project_root_dir, "VERSION")
+
+# Read and store the version information from the VERSION file
+# Use 'strip()' to remove any leading/trailing whitespace or newline characters
+with open(version_file_path, "r") as version_file:
+    __version__ = version_file.read().strip()
+
+# Define the public API for the module
+__all__ = ["__version__"]


### PR DESCRIPTION
This pull request includes significant updates to the GPU intrinsic functions for decoding and interleaving weights in the `bitblas` library. The changes mainly focus on enhancing the decoding process with additional features and fixing a bug in the interleaving function.

Enhancements to decoding functions:

* [`bitblas/gpu/intrin/lop3.py`](diffhunk://#diff-15fd74b90c3b956e9864e35778f26b27f6c9a7cfae35037967f420fda9a0bbe5L688-R752): Introduced a new template function `decode_i1b_to_f16` with additional parameters for signed integers, scaling, and zero handling. This function supports different modes for zero handling (original, rescale, quantized) and includes the necessary logic for these modes.

Bug fix in interleaving function:

* [`bitblas/ops/lop3_permutate/lop3_permutate_impl.py`](diffhunk://#diff-34cc17d2667f2378edb72862f94c1878bfd237091a0aa4434185602a78d2e3ebL83-R83): Corrected the bitmask and shift operation in the interleaving function to properly handle the upper bits of the input.