### PR TITLE
Fix: Remove composable_kernel include from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -269,21 +269,6 @@ class BitBLASBuilPydCommand(build_py):
                 if not os.path.exists(target_dir):
                     os.makedirs(target_dir)
                 shutil.copy2(source_dir, target_dir)
-        # copy compoable kernel to the package directory
-        CK_PREBUILD_ITEMS = [
-            "3rdparty/composable_kernel",
-        ]
-        for item in CK_PREBUILD_ITEMS:
-            source_dir = os.path.join(ROOT_DIR, item)
-            target_dir = os.path.join(self.build_lib, PACKAGE_NAME, item)
-            if os.path.isdir(source_dir):
-                self.mkpath(target_dir)
-                distutils.dir_util.copy_tree(source_dir, target_dir)
-            else:
-                target_dir = os.path.dirname(target_dir)
-                if not os.path.exists(target_dir):
-                    os.makedirs(target_dir)
-                shutil.copy2(source_dir, target_dir)
 
         # copy compoable kernel to the package directory
         CONFIG_ITEMS = ["VERSION", "README.md", "LICENSE"]


### PR DESCRIPTION
This pull request removes the composable_kernel include from setup.py, as it was causing a compilation failure due to missing submodule support. This resolves the issue mentioned in #278. 