### PR TITLE
[Dev] Fix bugs for ROCm with our default TileLang Backend

### DIFF
--- a/bitblas/__init__.py
+++ b/bitblas/__init__.py
@@ -147,7 +147,7 @@ from .relax import (
     ApplyDefaultSchedule,  # noqa: F401
     ApplyFastTuning,  # noqa: F401
 )
-from .utils import auto_detect_nvidia_target, apply_transform_on_input  # noqa: F401
+from .utils import auto_detect_target, auto_detect_nvidia_target, apply_transform_on_input  # noqa: F401
 from .ops.general_matmul import MatmulConfig, Matmul  # noqa: F401
 from .ops.general_matmul_splitk import MatmulConfigWithSplitK, MatmulWithSplitK  # noqa: F401
 from .ops.general_flashatten import FlashAttenConfig, FlashAtten  # noqa: F401

--- a/bitblas/base/arch/__init__.py
+++ b/bitblas/base/arch/__init__.py
@@ -6,6 +6,7 @@ from .cpu import CPU
 from .cdna import CDNA
 from typing import Union
 from tvm.target import Target
+from bitblas.utils.target_detector import auto_detect_target
 
 
 def get_arch(target: Union[str, Target] = "cuda") -> TileDevice:
@@ -22,12 +23,6 @@ def get_arch(target: Union[str, Target] = "cuda") -> TileDevice:
         raise ValueError(f"Unsupported target: {target.kind.name}")
 
 
-def auto_infer_current_arch() -> TileDevice:
-    # TODO(lei): This is a temporary solution to infer the current architecture
-    # Can be replaced by a more sophisticated method in the future
-    return get_arch("cuda")
-
-
 from .cpu import is_cpu_arch  # noqa: F401
 from .cuda import (
     is_cuda_arch,  # noqa: F401
@@ -38,4 +33,9 @@ from .cuda import (
     is_tensorcore_supported_precision,  # noqa: F401
     has_mma_support,  # noqa: F401
 )
-from .cdna import is_cdna_arch  # noqa: F401
+from .cdna import is_cdna_arch, is_matrixcore_supported_precision  # noqa: F401
+
+
+def auto_infer_current_arch() -> TileDevice:
+    target = auto_detect_target()
+    return get_arch(target)

--- a/bitblas/base/arch/cdna.py
+++ b/bitblas/base/arch/cdna.py
@@ -11,6 +11,21 @@ def is_cdna_arch(arch: TileDevice) -> bool:
     return isinstance(arch, CDNA)
 
 
+# AMD Matrix Core Configurations
+cdna_matrixcore_supported = [
+    ("float16", "float32"),
+    ("int8", "int32"),
+]
+
+
+def is_matrixcore_supported_precision(in_dtype: str, accum_dtype: str, arch: TileDevice) -> bool:
+
+    if is_cdna_arch(arch):
+        return (in_dtype, accum_dtype) in cdna_matrixcore_supported
+    else:
+        raise ValueError(f"Unsupported architecture: {arch}")
+
+
 class CDNA(TileDevice):
 
     def __init__(self, target: Union[Target, str]):

--- a/bitblas/base/arch/cuda.py
+++ b/bitblas/base/arch/cuda.py
@@ -18,40 +18,35 @@ def is_cuda_arch(arch: TileDevice) -> bool:
 
 def is_volta_arch(arch: TileDevice) -> bool:
     conditions = [True]
-    conditions.append(is_cuda_arch(arch))
-    conditions.append(arch.sm_version >= 70)
-    conditions.append(arch.sm_version < 80)
+    conditions.append(is_cuda_arch(arch) and arch.sm_version >= 70 and arch.sm_version < 80)
     return all(conditions)
 
 
 def is_ampere_arch(arch: TileDevice) -> bool:
     conditions = [True]
-    conditions.append(is_cuda_arch(arch))
-    conditions.append(arch.sm_version >= 80 and arch.sm_version < 90)
+    conditions.append(is_cuda_arch(arch) and arch.sm_version >= 80 and arch.sm_version < 90)
     return all(conditions)
 
 
 def is_ada_arch(arch: TileDevice) -> bool:
     conditions = [True]
-    conditions.append(is_cuda_arch(arch))
-    conditions.append(arch.sm_version == 89)
+    conditions.append(is_cuda_arch(arch) and arch.sm_version == 89)
     return all(conditions)
 
 
 def is_hopper_arch(arch: TileDevice) -> bool:
     conditions = [True]
-    conditions.append(is_cuda_arch(arch))
-    conditions.append(arch.sm_version == 90)
+    conditions.append(is_cuda_arch(arch) and arch.sm_version == 90)
     return all(conditions)
 
 
 def has_mma_support(arch: TileDevice) -> bool:
     conditions = [True]
-    conditions.append(is_cuda_arch(arch))
-    conditions.append(arch.sm_version >= 80)
+    conditions.append(is_cuda_arch(arch) and arch.sm_version >= 80)
     return all(conditions)
 
 
+# NVIDIA Tensor Core Configurations
 volta_tensorcore_supported = [
     ("float16", "float32"),
     ("float16", "float16"),

--- a/bitblas/benchmark/operator/__init__.py
+++ b/bitblas/benchmark/operator/__init__.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, List, Tuple, Optional
 from bitblas.ops import Operator, OperatorConfig
 from bitblas.utils import get_default_cache_path
-from bitblas import auto_detect_nvidia_target
+from bitblas import auto_detect_target
 from bitblas import tvm as tvm
 from bitblas.cache import OperatorCache
 import logging
@@ -21,7 +21,7 @@ class BitblasOperatorBenchmarkBase(ABC):
     benchmark_sets: Dict[str, List[Tuple[Operator, OperatorConfig, Optional[int]]]] = {}
 
     # Currently we only support NVIDIA target for benchmarking
-    benchmark_target: str = auto_detect_nvidia_target()
+    benchmark_target: str = auto_detect_target()
 
     # Benchmark results: a list of tuples, each containing latency and tuning time
     benchmark_results: Dict[str, List[Tuple[Optional[float], Optional[float]]]] = {}

--- a/bitblas/builder/wrapper/tl.py
+++ b/bitblas/builder/wrapper/tl.py
@@ -87,6 +87,9 @@ class TLCUDASourceWrapper(object):
         init_funcs = PREDEF_INIT_FUNC.format(call_str)
         return init_funcs
 
+    def get_stream_argument(self) -> Dict:
+        return {"name": "stream=cudaStreamDefault", "type": "cudaStream_t"}
+
     def update_lib_code(self, code: str):
         # Update the library code with the given code string
         self.lib_code = code
@@ -115,7 +118,7 @@ class TLCUDASourceWrapper(object):
         for dyn_sym in dynamic_symbolic_set:
             function_args.append({"name": dyn_sym, "type": "int"})
 
-        function_args.append({"name": "stream=cudaStreamDefault", "type": "cudaStream_t"},)
+        function_args.append(self.get_stream_argument())
         # Format the function arguments for declaration
         def_args = ", ".join([f"{arg['type']} {arg['name']}" for arg in function_args])
 
@@ -223,7 +226,7 @@ class TLCUDASourceWrapperWithDynamic(TLCUDASourceWrapper):
         for dyn_sym in dynamic_symbolic_set:
             function_args.append({"name": dyn_sym, "type": "int"})
 
-        function_args.append({"name": "stream=cudaStreamDefault", "type": "cudaStream_t"},)
+        function_args.append(self.get_stream_argument())
 
         # Format the argument definitions for function declaration
         def_args = ", ".join([f"{arg['type']} {arg['name']}" for arg in function_args])
@@ -392,8 +395,8 @@ class TLHIPSourceWrapper(TLCUDASourceWrapper):
         init_funcs = PREDEF_INIT_FUNC.format(call_str)
         return init_funcs
 
-    def get_stream_type(self, function_args):
-        function_args.append({"name": "stream=hipStreamDefault", "type": "hipStream_t"},)
+    def get_stream_argument(self) -> Dict:
+        return {"name": "stream=hipStreamDefault", "type": "hipStream_t"}
 
 
 class TLWrapper(BaseWrapper):

--- a/bitblas/cache/operator.py
+++ b/bitblas/cache/operator.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 import bitblas
-from bitblas.utils import get_default_cache_path
+from bitblas.utils import get_default_cache_path, auto_detect_target
 from bitblas.ops.operator import OperatorConfig, Operator
 from dataclasses import asdict
 import os
@@ -186,7 +186,7 @@ def load_global_ops_cache(database_path=None, target=None):
     if database_path is None:
         database_path = get_database_path()
     if target is None:
-        target = bitblas.auto_detect_nvidia_target()
+        target = auto_detect_target()
     logger.info(f"Loading operators from database {database_path} for target {target}")
     global_operator_cache.load_from_database(database_path, target)
     return global_operator_cache

--- a/bitblas/module/__init__.py
+++ b/bitblas/module/__init__.py
@@ -16,7 +16,7 @@ from typing import List, Union, Optional
 from bitblas.cache import global_operator_cache, get_database_path
 from bitblas import Matmul, MatmulConfig
 from bitblas.quantization.utils import general_compress
-from bitblas import auto_detect_nvidia_target
+from bitblas import auto_detect_target
 
 BITBLAS_DATABASE_PATH = get_database_path()
 
@@ -240,7 +240,7 @@ class Linear(nn.Module):
         self.source_format = self.bitblas_matmul.source_format
 
     def _get_or_create_bitblas_operator(self, config, enable_tuning):
-        BITBLAS_TARGET = auto_detect_nvidia_target()
+        BITBLAS_TARGET = auto_detect_target()
 
         if global_operator_cache.size() == 0:
             global_operator_cache.load_from_database(BITBLAS_DATABASE_PATH, BITBLAS_TARGET)

--- a/bitblas/ops/general_flashatten/__init__.py
+++ b/bitblas/ops/general_flashatten/__init__.py
@@ -6,7 +6,7 @@ from .tilelang import select_scheduler as consistent_scheduler
 from bitblas.base.base_scheduler import BaseScheduler
 from ..operator import OperatorConfig, Operator, BaseKernelNameGenerator
 from ...base.arch.cuda import CUDA
-from ...utils import auto_detect_nvidia_target
+from ...utils import auto_detect_target
 from dataclasses import dataclass
 from typing import Union, Tuple, Literal, Optional, Any
 import logging
@@ -93,7 +93,7 @@ class FlashAtten(Operator):
         backend: str = "tl",
     ):
         if target is None:
-            target = auto_detect_nvidia_target()
+            target = auto_detect_target()
             logger.info(f"Auto detected target: {target}")
 
         assert (config.Q_dtype

--- a/bitblas/ops/general_matmul/__init__.py
+++ b/bitblas/ops/general_matmul/__init__.py
@@ -16,7 +16,7 @@ from .tilelang.dense import select_scheduler as consistent_scheduler
 from .tilelang.dequantize import select_scheduler as weight_dequantize_scheduler
 from ...base.utils import tensor_replace_dp4a, tensor_remove_make_int4, tensor_remove_make_int2
 from bitblas.utils import retrieve_func_from_module
-from bitblas.utils.target_detector import auto_detect_nvidia_target
+from bitblas.utils.target_detector import auto_detect_target
 from dataclasses import dataclass
 from ..ladder_permutate import LadderPermutate, LadderPermutateConfig
 from ..quant_compress import QuantCompress, QuantCompressConfig
@@ -356,7 +356,7 @@ class Matmul(Operator):
         # if from database, we should disable default schedule
         # to save compilation time
         if target is None:
-            target = auto_detect_nvidia_target()
+            target = auto_detect_target()
             logger.info(f"Auto detected target: {target}")
 
         assert (config.A_dtype

--- a/bitblas/ops/general_matmul/tilelang/dense/matmul.py
+++ b/bitblas/ops/general_matmul/tilelang/dense/matmul.py
@@ -5,12 +5,8 @@ from typing import Optional, List, Dict
 from tvm.tir import PrimFunc
 from bitblas.base.operator_common import TransformKind
 from bitblas.base.base_scheduler import BaseScheduler
-from bitblas.base.arch import (
-    TileDevice,
-    is_ampere_arch,
-    is_volta_arch,
-    is_tensorcore_supported_precision,
-)
+from bitblas.base.arch import (TileDevice, is_ampere_arch, is_volta_arch, is_cdna_arch,
+                               is_tensorcore_supported_precision, is_matrixcore_supported_precision)
 from dataclasses import dataclass
 from bitblas.tl.base_hint import BaseTLHint
 
@@ -128,11 +124,46 @@ class MatmulScheduler(MatmulBaseParams):
             else:
                 return self.matmul_simt_scheduler
 
+    def dispatch_cdna_scheduler(self, arch: TileDevice) -> BaseScheduler:
+        M = self.maybe_dynamic(self.M, "m")
+        N, K = self.N, self.K
+        assert isinstance(N, int) and isinstance(K, int), "Do not support dynamic N and K Currently"
+
+        is_dynamic = self.is_dynamic
+        in_dtype, accum_dtype = (
+            self.in_dtype,
+            self.accum_dtype,
+        )
+        if self.weight_transform_kind != TransformKind.NonTransform:
+            raise ValueError(
+                f"Weight propagation {self.weight_transform_kind} is not supported for CDNA")
+        if in_dtype not in ["int8", "float16", "float32", "float64"]:
+            raise ValueError(f"Unsupported input data type: {in_dtype}")
+
+        if is_dynamic:
+            # Dynamic Dispatcher
+            if is_matrixcore_supported_precision(in_dtype, accum_dtype, arch):
+                return self.matmul_block_scheduler
+            else:
+                return self.matmul_simt_scheduler
+        else:
+            minimal_tensorcore_threshold: List[int, int, int] = [8, 16, 16]
+            if minimal_tensorcore_threshold[0] > M or minimal_tensorcore_threshold[
+                    1] > N or minimal_tensorcore_threshold[2] > K:
+                return self.gemv_scheduler
+            elif is_matrixcore_supported_precision(in_dtype, accum_dtype, arch):
+                # Fine-grained scheduler (mma) is not implemented for CDNA
+                return self.matmul_block_scheduler
+            else:
+                return self.matmul_simt_scheduler
+
     def dispatch_scheduler(self, arch: TileDevice) -> BaseScheduler:
         if is_ampere_arch(arch):
             return self.dispatch_ampere_scheduler(arch)
         elif is_volta_arch(arch):
             return self.dispatch_volta_scheduler(arch)
+        elif is_cdna_arch(arch):
+            return self.dispatch_cdna_scheduler(arch)
         else:
             raise ValueError(f"Unsupported architecture: {arch}")
 

--- a/bitblas/ops/operator.py
+++ b/bitblas/ops/operator.py
@@ -278,7 +278,7 @@ class Operator(object):
             self._update_optimized_mod(scheduled_ir_module)
         except Exception as apply_schedule_error:
             self.scheduled_ir_module = None
-            logger.warning(
+            logger.exception(
                 APPLY_SCHEDULE_FAILED_MESSAGE.format(self.__class__.__name__, target, "default",
                                                      apply_schedule_error))
 

--- a/bitblas/utils/__init__.py
+++ b/bitblas/utils/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 from .post_process import match_global_kernel, tensor_replace_dp4a, tensor_remove_make_int4, tensor_remove_make_int2  # noqa: F401
 from .tensor_adapter import tvm_tensor_to_torch, lazy_tvm_tensor_to_torch, lazy_torch_to_tvm_tensor  # noqa: F401
-from .target_detector import get_all_nvidia_targets, auto_detect_nvidia_target  # noqa: F401
+from .target_detector import auto_detect_target, get_all_nvidia_targets, auto_detect_nvidia_target  # noqa: F401
 from .rtmod_analysis import get_annotated_device_mod  # noqa: F401
 from .weight_propagate import apply_transform_on_input  # noqa: F401
 


### PR DESCRIPTION
This pull request includes significant changes to enhance the target detection functionality and streamline the codebase. The most important changes involve the introduction of a new `auto_detect_target` function, the removal of redundant code, and the consolidation of target detection logic.

Enhancements to target detection:

* [`bitblas/utils/target_detector.py`](diffhunk://#diff-e257cd91727ec02147aac133fcf28b9cc366d0dae6443fe92519a39fd8e497c5R106-R150): Introduced the `auto_detect_target` function to detect the computing target (CUDA or ROCm) based on the environment, replacing the previous `auto_detect_nvidia_target` function in various parts of the codebase. [[1]](diffhunk://#diff-e257cd91727ec02147aac133fcf28b9cc366d0dae6443fe92519a39fd8e497c5R106-R150) [[2]](diffhunk://#diff-e257cd91727ec02147aac133fcf28b9cc366d0dae6443fe92519a39fd8e497c5R26) [[3]](diffhunk://#diff-e257cd91727ec02147aac133fcf28b9cc366d0dae6443fe92519a39fd8e497c5R56)

Codebase simplification:

* [`bitblas/__init__.py`](diffhunk://#diff-c2248c838997d60356d36c7ad50e42b7bfcc09238719cc55cccb6b87e48472e7L150-R150): Replaced `auto_detect_nvidia_target` with `auto_detect_target` in the import statement.
* [`bitblas/base/arch/__init__.py`](diffhunk://#diff-114991a695eb42a61b67e97cdfd40f4c58b61d7998a547d448570a5f3eab4c76R9): Removed the temporary `auto_infer_current_arch` function and added the new `auto_detect_target` function. [[1]](diffhunk://#diff-114991a695eb42a61b67e97cdfd40f4c58b61d7998a547d448570a5f3eab4c76R9) [[2]](diffhunk://#diff-114991a695eb42a61b67e97cdfd40f4c58b61d7998a547d448570a5f3eab4c76L25-L30) [[3]](diffhunk://#diff-114991a695eb42a61b67e97cdfd40f4c58b61d7998a547d448570a5f3eab4c76L41-R41)
* [`bitblas/benchmark/operator/__init__.py`](diffhunk://#diff-1c96c27c628d3e2d720450b843bdf5661ff5f84a10032312779f85f14b766a54L10-R10): Updated the `BitblasOperatorBenchmarkBase` class to use `auto_detect_target` instead of `auto_detect_nvidia_target`. [[1]](diffhunk://#diff-1c96c27c628d3e2d720450b843bdf5661ff5f84a10032312779f85f14b766a54L10-R10) [[2]](diffhunk://#diff-1c96c27c628d3e2d720450b843bdf5661ff5f84a10032312779f85f14b766a54L24-R24)
* [`bitblas/cache/operator.py`](diffhunk://#diff-f8a4e09cbf6dfcad69926fd793e0d0e61ce69b4732bfa515c16fded27079b3c5L4-R4): Updated the `load_global_ops_cache` function to use `auto_detect_target` instead of `auto_detect_nvidia_target`. [[1]](diffhunk://#diff-f8a4e09cbf6dfcad69926fd793e0d0e61ce69b4732bfa515c16fded27079b3c5L4-R4) [[2]](diffhunk://#diff-f8a4e09cbf6dfcad69926fd793e0d0e61ce69b4732bfa515c16fded27079b3c5L189-R189)



Note that currently only support consistent precision, dequantize op is coming soon.